### PR TITLE
Fork ts loader

### DIFF
--- a/examples/react-ssr-example/package.json
+++ b/examples/react-ssr-example/package.json
@@ -48,11 +48,11 @@
     "@types/express-winston": "3.0.0",
     "@types/lodash": "4.14.118",
     "@types/node": "8.10.37",
-    "@types/react": "16.7.6",
-    "@types/react-dom": "16.0.9",
+    "@types/react": "16.7.17",
+    "@types/react-dom": "16.0.11",
     "@types/react-helmet": "5.0.7",
-    "@types/react-redux": "6.0.9",
-    "@types/react-router": "4.4.1",
+    "@types/react-redux": "6.0.11",
+    "@types/react-router": "4.4.3",
     "@types/react-router-dom": "4.3.1",
     "@types/sinon": "5.0.7",
     "@types/storybook__addon-actions": "3.4.1",
@@ -72,6 +72,9 @@
     "supertest": "3.3.0",
     "webpack": "4.25.1",
     "webpack-flush-chunks": "2.0.3"
+  },
+  "resolutions": {
+    "@types/react": "16.7.17"
   },
   "devEngines": {
     "node": "8.x || 9.x || 10.x"

--- a/examples/react-ssr-example/tsconfig.json
+++ b/examples/react-ssr-example/tsconfig.json
@@ -36,6 +36,10 @@
   "exclude": [
     "**/*.stories.ts",
     "**/*.test.ts",
-    "**/node_modules"
+    "dist",
+    "coverage",
+    "public",
+    "node_modules",
+    "**/node_modules/*"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clean": "lerna clean",
     "compile": "lerna run compile",
     "env:create": "lerna run env:create",
+    "link": "lerna link",
     "lint": "lerna run lint",
     "test": "lerna run test",
     "pretty": "lerna run pretty",

--- a/packages/pixeloven-tasks/package.json
+++ b/packages/pixeloven-tasks/package.json
@@ -39,6 +39,7 @@
     "dotenv-webpack": "1.5.7",
     "express": "4.16.4",
     "file-loader": "2.0.0",
+    "fork-ts-checker-webpack-plugin": "0.5.2",
     "fs-extra": "7.0.1",
     "html-entities": "1.2.1",
     "html-webpack-plugin": "3.2.0",

--- a/packages/pixeloven-tasks/src/configs/webpack/client.ts
+++ b/packages/pixeloven-tasks/src/configs/webpack/client.ts
@@ -4,6 +4,7 @@ import autoprefixer from "autoprefixer";
 import CaseSensitivePathsPlugin from "case-sensitive-paths-webpack-plugin";
 import CopyWebpackPlugin from "copy-webpack-plugin";
 import Dotenv from "dotenv-webpack";
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import OfflinePlugin from "offline-plugin";
@@ -179,7 +180,7 @@ const typeScriptRule: RuleSetRule = {
             loader: require.resolve("ts-loader"),
             options: {
                 configFile: resolvePath("tsconfig.json"),
-                // transpileOnly: true,
+                transpileOnly: true,
             },
         },
     ],
@@ -330,18 +331,15 @@ const plugins: Plugin[] = removeEmpty([
     }),
     /**
      * Perform type checking and linting in a separate process to speed up compilation
-     * TODO might prevent showing errors in browser if async is off... but then again it breaks hmr overlay
      * @env all
      */
-    // import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
-    // ifProduction(new ForkTsCheckerWebpackPlugin({
-    //     tsconfig: resolvePath("tsconfig.json"),
-    //     tslint: resolvePath("tslint.json"),
-    // }), new ForkTsCheckerWebpackPlugin({
-    //     tsconfig: resolvePath("tsconfig.json"),
-    //     tslint: resolvePath("tslint.json"),
-    //     watch: resolvePath("src"),
-    // })),
+    ifProduction(new ForkTsCheckerWebpackPlugin({
+        tsconfig: resolvePath("tsconfig.json"),
+    }), new ForkTsCheckerWebpackPlugin({
+        async: true,
+        tsconfig: resolvePath("tsconfig.json"),
+        watch: resolvePath("src"),
+    })),
 
     /**
      * Copy files

--- a/packages/pixeloven-tasks/src/configs/webpack/server.ts
+++ b/packages/pixeloven-tasks/src/configs/webpack/server.ts
@@ -2,6 +2,7 @@ import { resolvePath } from "@pixeloven/core";
 import { env } from "@pixeloven/env";
 import CaseSensitivePathsPlugin from "case-sensitive-paths-webpack-plugin";
 import Dotenv from "dotenv-webpack";
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import ModuleScopePlugin from "react-dev-utils/ModuleScopePlugin";
 import TimeFixPlugin from "time-fix-plugin";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
@@ -102,7 +103,7 @@ const typeScriptRule: RuleSetRule = {
             loader: require.resolve("ts-loader"),
             options: {
                 configFile: resolvePath("tsconfig.json"),
-                // transpileOnly: true,
+                transpileOnly: true,
             },
         },
     ],
@@ -196,18 +197,15 @@ const plugins: Plugin[] = removeEmpty([
     }),
     /**
      * Perform type checking and linting in a separate process to speed up compilation
-     * TODO might prevent showing errors in browser if async is off... but then again it breaks hmr overlay
      * @env all
      */
-    // import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
-    // ifProduction(new ForkTsCheckerWebpackPlugin({
-    //     tsconfig: resolvePath("tsconfig.json"),
-    //     tslint: resolvePath("tslint.json"),
-    // }), new ForkTsCheckerWebpackPlugin({
-    //     tsconfig: resolvePath("tsconfig.json"),
-    //     tslint: resolvePath("tslint.json"),
-    //     watch: resolvePath("src"),
-    // })),
+    ifProduction(new ForkTsCheckerWebpackPlugin({
+        tsconfig: resolvePath("tsconfig.json"),
+    }), new ForkTsCheckerWebpackPlugin({
+        async: true,
+        tsconfig: resolvePath("tsconfig.json"),
+        watch: resolvePath("src"),
+    })),
 ]);
 
 /**


### PR DESCRIPTION
Significantly increases build time even with async: true. We seem to lose a little bit of error context but at the same time we appear to gain a simple stack trace in console.
```
✖ ｢core｣: (client) /home/brian/Documents/Development/pixeloven/examples/react-ssr-example/src/shared/components/pages/Home/Home.tsx
./src/shared/components/pages/Home/Home.tsx
[tsl] ERROR in /home/brian/Documents/Development/pixeloven/examples/react-ssr-example/src/shared/components/pages/Home/Home.tsx(33,37)
      TS17002: Expected corresponding JSX closing tag for 'asdsda'.
 @ ./src/shared/components/pages/Home/index.ts 10:13-30
 @ ./src/shared/components/pages/index.ts
 @ ./src/shared/routes.ts
 @ ./src/client/index.tsx
```

Might explore forking the overlay and error handler to better integrate with this plugin.