### PR TITLE
Issue 78 add decorator for modal portals to bind to empty div

### DIFF
--- a/packages/pixeloven-docs/src/configs/config.tsx
+++ b/packages/pixeloven-docs/src/configs/config.tsx
@@ -2,6 +2,7 @@ import { withBackgrounds } from "@storybook/addon-backgrounds";
 import { withKnobs } from "@storybook/addon-knobs";
 import { withOptions } from "@storybook/addon-options";
 import { addDecorator, configure } from "@storybook/react";
+import React from 'react';
 
 /**
  * Import remote assets dynamically
@@ -29,6 +30,20 @@ addDecorator(
     ]),
 );
 addDecorator(withKnobs);
+
+
+/**
+ * Wrapper with custom id for modals to attach to
+ */
+const modalContainerDecorator = (storyFn: () => {}) => (
+    <>
+        <div id= "modal-root" />
+        <div id="root" >
+            { storyFn() }
+        </div>
+    </>
+);
+addDecorator(modalContainerDecorator);
 
 /**
  * Stories loader

--- a/packages/pixeloven-docs/src/configs/config.tsx
+++ b/packages/pixeloven-docs/src/configs/config.tsx
@@ -37,7 +37,7 @@ addDecorator(withKnobs);
  */
 const modalContainerDecorator = (storyFn: () => {}) => (
     <>
-        <div id= "modal-root" />
+        <div id="modal-root" />
         <div id="root" >
             { storyFn() }
         </div>


### PR DESCRIPTION
- Added a decorator in storybook config that adds a div with id="modal-root" for portal modals to bind to