### PR TITLE
Rebuilding middle-ware to allow for more flexibility

### DIFF
--- a/packages/pixeloven-webpack-hot-server-middleware/README.md
+++ b/packages/pixeloven-webpack-hot-server-middleware/README.md
@@ -1,0 +1,19 @@
+# @pixeloven/webpack-hot-server-middleware
+
+> Pixel Oven Webpack hot server middleware.
+
+See our website [pixeloven-webpack-hot-server-middleware](https://github.com/pixeloven/pixeloven) for more information or the [issues](https://github.com/pixeloven/pixeloven) associated with this package.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save @pixeloven/webpack-hot-server-middleware
+```
+
+or using yarn:
+
+```sh
+yarn add @pixeloven/webpack-hot-server-middleware
+```

--- a/packages/pixeloven-webpack-hot-server-middleware/jestrc.json
+++ b/packages/pixeloven-webpack-hot-server-middleware/jestrc.json
@@ -1,0 +1,41 @@
+{
+  "bail": true,
+  "verbose": true,
+  "preset": "ts-jest",
+  "transform": {
+    "^.+\\.(ts|tsx)$": "ts-jest"
+  },
+  "transformIgnorePatterns": [
+    "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$"
+  ],
+  "testMatch": [
+    "<rootDir>/src/**/test/**/*.(j|t)s?(x)",
+    "<rootDir>/src/**/?(*.)(spec|test).(j|t)s?(x)"
+  ],
+  "testEnvironment": "node",
+  "testURL": "http://localhost",
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "jsx",
+    "ts",
+    "tsx"
+  ],
+  "coveragePathIgnorePatterns": [
+    "/node_modules/",
+    "/test/"
+  ],
+  "coverageThreshold": {
+    "global": {
+      "branches": 100,
+      "functions": 100,
+      "lines": 100,
+      "statements": 100
+    }
+  },
+  "collectCoverage": true,
+  "collectCoverageFrom": [
+    "<rootDir>/src/**/*.{js,jsx,ts,tsx}",
+    "!**/node_modules/**"
+  ]
+}

--- a/packages/pixeloven-webpack-hot-server-middleware/package.json
+++ b/packages/pixeloven-webpack-hot-server-middleware/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@pixeloven/webpack-hot-server-middleware",
+  "version": "3.2.1",
+  "description": "Webpack hot server middleware",
+  "main": "dist/lib/index.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/"
+  ],
+  "homepage": "https://github.com/pixeloven/pixeloven",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pixeloven/pixeloven.git"
+  },
+  "author": "Brian Gebel",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pixeloven/cli": "^3.2.1",
+    "require-from-string" :"2.0.2",
+    "source-map-support" : "0.5.10"
+  },
+  "devDependencies": {
+    "@types/express": "4.16.0",
+    "@types/node": "10.12.12",
+    "@types/require-from-string" : "1.2.0",
+    "@types/source-map-support" : "0.4.1",
+    "@types/webpack": "4.4.22",
+    "express": "4.16.4",
+    "webpack": "4.28.2"
+  },
+  "peerDependencies": {
+    "express" : "4.x",
+    "webpack" : "4.x"
+  },
+  "scripts": {
+    "prepublishOnly": "yarn lint && yarn test && yarn compile",
+    "clean": "pixeloven-cli clean",
+    "compile": "pixeloven-cli compile:ts",
+    "precompile": "pixeloven-cli compile:clean",
+    "document": "pixeloven-cli document:ts src",
+    "predocument": "pixeloven-cli document:clean",
+    "lint": "yarn lint:ts",
+    "lint:ts": "pixeloven-cli lint:ts src/**/*.{ts,tsx}",
+    "pretest": "pixeloven-cli test:clean",
+    "pretty": "pixeloven-cli pretty src/**/*.{ts,tsx}",
+    "pretty:ts": "pixeloven-cli pretty:ts src/**/*.{ts,tsx}",
+    "test": "pixeloven-cli test --color --coverage",
+    "test:watch": "pixeloven-cli test:watch"
+  }
+}

--- a/packages/pixeloven-webpack-hot-server-middleware/prettierrc.json
+++ b/packages/pixeloven-webpack-hot-server-middleware/prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "trailingComma": "all",
+    "tabWidth": 4
+}

--- a/packages/pixeloven-webpack-hot-server-middleware/src/index.test.ts
+++ b/packages/pixeloven-webpack-hot-server-middleware/src/index.test.ts
@@ -1,0 +1,7 @@
+import "jest";
+
+describe("@pixeloven/webpack-hot-server-middleware", () => {
+    describe("index", () => {
+        // TODO
+    });
+});

--- a/packages/pixeloven-webpack-hot-server-middleware/src/index.ts
+++ b/packages/pixeloven-webpack-hot-server-middleware/src/index.ts
@@ -1,0 +1,213 @@
+/* tslint:disable:no-any */
+import {NextFunction, Request, Response} from "express";
+import path from "path";
+import requireFromString from "require-from-string";
+import sourceMapSupport from "source-map-support";
+import { Compiler, MultiCompiler, Stats } from "webpack";
+
+interface MiddlewareOptions {
+    chunkName: string,
+    createHandler: any,
+    serverRendererOptions: object,
+}
+
+interface ServerEntryPoint {
+    __esModule: any;
+    default: any;
+}
+
+const debug = (msg: string) => {
+    console.log(msg);
+};
+
+const createConnectHandler = (error: Error, serverRenderer: any) => (req: Request, res: Response, next: NextFunction) => {
+    debug(`Receive request ${req.url}`);
+    if (error) {
+        return next(error);
+    }
+    serverRenderer(req, res, next);
+};
+
+function interopRequireDefault(obj: ServerEntryPoint) {
+    return obj && obj.__esModule ? obj.default : obj;
+}
+
+function isMultiCompiler(compiler: any) {
+    // Duck typing as `instanceof MultiCompiler` fails when npm decides to
+    // install multiple instances of webpack.
+    return compiler && compiler.compilers;
+}
+
+function findCompiler(multiCompiler: MultiCompiler, name: string) {
+    return multiCompiler.compilers.filter(
+        (compiler: Compiler) => compiler.name.indexOf(name) === 0,
+    );
+}
+
+function findStats(multiStats: any, name: string) {
+    return multiStats.stats.filter(
+        (stats: any) => stats.compilation.name.indexOf(name) === 0,
+    );
+}
+
+function getFilename(serverStats: Stats, outputPath: string, chunkName: string) {
+    const assetsByChunkName = serverStats.toJson().assetsByChunkName;
+    const filename = assetsByChunkName[chunkName] || "";
+    // If source maps are generated `assetsByChunkName.main`
+    // will be an array of filenames.
+    return path.join(
+        outputPath,
+        Array.isArray(filename)
+            ? filename.find(asset => /\.js$/.test(asset))
+            : filename,
+    );
+}
+
+function getServerRenderer(filename: string, buffer: Buffer, options: any) {
+    const errMessage = `The 'server' compiler must export a function in the form of \`(options) => (req, res, next) => void\``;
+
+    let serverRenderer = interopRequireDefault(
+        requireFromString(buffer.toString(), filename),
+    );
+    if (typeof serverRenderer !== "function") {
+        throw new Error(errMessage);
+    }
+
+    serverRenderer = serverRenderer(options);
+    if (typeof serverRenderer !== "function") {
+        throw new Error(errMessage);
+    }
+
+    return serverRenderer;
+}
+
+function installSourceMapSupport(fs: any) {
+    sourceMapSupport.install({
+        // NOTE: If https://github.com/evanw/node-source-map-support/pull/149
+        // lands we can be less aggressive and explicitly invalidate the source
+        // map cache when Webpack recompiles.
+        emptyCacheBetweenOperations: true,
+        retrieveFile(source) {
+            try {
+                return fs.readFileSync(source, "utf8");
+            } catch (ex) {
+                // Doesn't exist
+            }
+        },
+    });
+}
+
+/**
+ * Setup default options
+ */
+const DEFAULTS: MiddlewareOptions = {
+    chunkName: "main",
+    createHandler: createConnectHandler,
+    serverRendererOptions: {},
+};
+
+/**
+ * Passes the request to the most up to date 'server' bundle.
+ * NOTE: This must be mounted after webpackDevMiddleware to ensure this
+ * middleware doesn't get called until the compilation is complete.
+ * @param   {MultiCompiler} multiCompiler                  e.g webpack([clientConfig, serverConfig])
+ * @options {String}        options.chunkName              The name of the main server chunk.
+ * @options {Object}        options.serverRendererOptions  Options passed to the `serverRenderer`.
+ * @return  {Function}                                     Middleware fn.
+ */
+function webpackHotServerMiddleware(multiCompiler: MultiCompiler, options: MiddlewareOptions) {
+    debug("Using webpack-hot-server-middleware");
+
+    options = Object.assign({}, DEFAULTS, options);
+
+    if (!isMultiCompiler(multiCompiler)) {
+        throw new Error(
+            `Expected webpack compiler to contain both a 'client' and/or 'server' config`,
+        );
+    }
+
+    const serverCompiler = findCompiler(multiCompiler, "server")[0];
+    const clientCompilers = findCompiler(multiCompiler, "client");
+
+    if (!serverCompiler) {
+        throw new Error(`Expected a webpack compiler named 'server'`);
+    }
+    if (!clientCompilers.length) {
+        debug(
+            `Cannot find webpack compiler named 'client'. Starting without client compiler`,
+        );
+    }
+
+    const outputFs = serverCompiler.outputFileSystem;
+    const outputPath = serverCompiler.outputPath; // TODO can we get this from stats???
+
+    installSourceMapSupport(outputFs);
+
+    let serverRenderer;
+    let error = false;
+
+    const doneHandler = multiStats => {
+        error = false;
+
+        const serverStats = findStats(multiStats, "server")[0];
+        // Server compilation errors need to be propagated to the client.
+        if (serverStats.compilation.errors.length) {
+            error = serverStats.compilation.errors[0];
+            return;
+        }
+
+        let clientStatsJson = null;
+
+        if (clientCompilers.length) {
+            const clientStats = findStats(multiStats, "client");
+            clientStatsJson = clientStats.map(obj => obj.toJson());
+
+            if (clientStatsJson.length === 1) {
+                clientStatsJson = clientStatsJson[0];
+            }
+        }
+
+        const filename = getFilename(
+            serverStats,
+            outputPath,
+            options.chunkName,
+        );
+        const buffer = outputFs.readFileSync(filename);
+        const serverRendererOptions = Object.assign(
+            {
+                clientStats: clientStatsJson,
+                serverStats: serverStats.toJson(),
+            },
+            options.serverRendererOptions,
+        );
+        try {
+            serverRenderer = getServerRenderer(
+                filename,
+                buffer,
+                serverRendererOptions,
+            );
+        } catch (ex) {
+            debug(ex);
+            error = ex;
+        }
+    };
+
+    // TODO split this by server and client???
+    if (multiCompiler.hooks) {
+        // Webpack 4
+        multiCompiler.hooks.done.tap("WebpackHotServerMiddleware", doneHandler);
+    } else {
+        // Webpack 3
+        multiCompiler.plugin("done", doneHandler);
+    }
+
+    return function() {
+        return options
+            .createHandler(error, serverRenderer)
+            .apply(null, arguments);
+    };
+}
+
+Object.assign(webpackHotServerMiddleware, { createConnectHandler });
+
+module.exports = webpackHotServerMiddleware;

--- a/packages/pixeloven-webpack-hot-server-middleware/tsconfig.json
+++ b/packages/pixeloven-webpack-hot-server-middleware/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../../tsconfig",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "declarationDir": "./dist/types",
+        "outDir": "./dist/lib",
+        "skipLibCheck": true
+    },
+    "exclude": [
+        "./**/*.stories.ts",
+        "./**/*.spec.ts",
+        "./**/*.test.ts",
+        "./coverage",
+        "./dist",
+        "./docs",
+        "./node_modules"
+    ],
+}

--- a/packages/pixeloven-webpack-hot-server-middleware/tslint.json
+++ b/packages/pixeloven-webpack-hot-server-middleware/tslint.json
@@ -1,0 +1,25 @@
+{
+  "defaultSeverity": "error",
+  "linterOptions": {
+    "exclude": [
+      "dist",
+      "coverage",
+      "node_modules"
+    ]
+  },
+  "extends": [
+    "tslint:latest",
+    "tslint-config-prettier",
+    "tslint-eslint-rules"
+  ],
+  "rules": {
+    "arrow-parens": false,
+    "prefer-object-spread": false,
+    "interface-name": false,
+    "no-implicit-dependencies": false,
+    "no-submodule-imports": false,
+    "no-console": false,
+    "no-any": true,
+    "no-null-keyword": true
+  }
+}

--- a/packages/pixeloven-webpack-hot-server-middleware/typedoc.json
+++ b/packages/pixeloven-webpack-hot-server-middleware/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "name": "@pixeloven/webpack-hot-server-middleware",
+    "target": "es5",
+    "out": "docs",
+    "exclude": "*.{test}.{ts}",
+    "externalPattern": "**/node_modules/**",
+    "excludeExternals": true,
+    "includeDeclarations": true
+}


### PR DESCRIPTION
I needed to rebuild https://www.npmjs.com/package/webpack-hot-server-middleware to fit our use cases. This first pass is an attempt to convert the existing middleware into typescript. 

However, I found some issues with this code...
``
    if (multiCompiler.hooks) {
        // Webpack 4
        multiCompiler.hooks.done.tap("WebpackHotServerMiddleware", doneHandler);
    } else {
        // Webpack 3
        multiCompiler.plugin("done", doneHandler);
    }
``
Either multi compiler hooks don't exist or the webpack types are not up-to-date.