### PR TITLE
Fixes the atomic type variable in various templates

### DIFF
--- a/packages/pixeloven-generators/src/templates/Component/Component.stories.tsx.hbs
+++ b/packages/pixeloven-generators/src/templates/Component/Component.stories.tsx.hbs
@@ -6,7 +6,7 @@ import { {{componentName}} } from "@shared/components/{{plural atomicType}}";
 
 import Readme from "./README.md";
 
-storiesOf("Components/{{capitalize (plural componentType)}}/{{componentName}}", module)
+storiesOf("Components/{{capitalize (plural atomicTypes)}}/{{componentName}}", module)
     .addDecorator(withReadme(Readme))
     .add("default", () => {
         return <{{componentName}} exampleProp={"example prop"} />;

--- a/packages/pixeloven-generators/src/templates/Component/Component.test.tsx.hbs
+++ b/packages/pixeloven-generators/src/templates/Component/Component.test.tsx.hbs
@@ -9,7 +9,7 @@ configure({
     adapter: new ReactSixteenAdapter(),
 });
 
-describe("Shared/Components/{{capitalize (plural componentType)}}/{{componentName}}", () => {
+describe("Shared/Components/{{capitalize (plural atomicTypes)}}/{{componentName}}", () => {
     it("should not render anything", () => {
         const wrapper = shallow(<{{componentName}} />);
 

--- a/packages/pixeloven-generators/src/templates/Component/README.md.hbs
+++ b/packages/pixeloven-generators/src/templates/Component/README.md.hbs
@@ -1,4 +1,4 @@
-# {{componentName}} {{capitalize componentType}} component
+# {{componentName}} {{capitalize atomicTypes}} component
 
 {{componentDescription}}
 


### PR DESCRIPTION
Missed a few variables when updating the componentType variable to functional vs class and converting the existing variable to atomicType. Minor issue but this fixes it.