### PR TITLE
chore: improve the component generator

### DIFF
--- a/packages/pixeloven-generators/src/generators.test.ts
+++ b/packages/pixeloven-generators/src/generators.test.ts
@@ -1,8 +1,12 @@
 import "jest";
 import generator, {
+    camelCase,
     capitalize,
+    firstChar,
+    kebabCase,
     lowerCase,
     makeValidateMinLength,
+    pascalCase,
     plural,
     upperCase,
     validateWord,
@@ -82,6 +86,11 @@ describe("@pixeloven/generators", () => {
                 expect(validateMinLength("t")).toEqual(true);
             });
         });
+        describe("firstChar", () => {
+            it("should return the first character as lower case", () => {
+                expect(firstChar("Test")).toEqual("t");
+            })
+        })
         describe("capitalize", () => {
             it("should lower case word and upper case first letter", () => {
                 expect(capitalize("TEST")).toEqual("Test");
@@ -100,6 +109,27 @@ describe("@pixeloven/generators", () => {
         describe("upperCase", () => {
             it("should upper case word", () => {
                 expect(upperCase("test")).toEqual("TEST");
+            });
+        });
+        describe("camelCase", () => {
+            it("should camel case word", () => {
+                expect(camelCase("TestWord")).toEqual("testWord");
+                expect(camelCase("Test word")).toEqual("testWord");
+                expect(camelCase("Test-word")).toEqual("testWord");
+            });
+        });
+        describe("pascalCase", () => {
+            it("should pascal case word", () => {
+                expect(pascalCase("testWord")).toEqual("TestWord");
+                expect(pascalCase("test word")).toEqual("TestWord");
+                expect(pascalCase("test-word")).toEqual("TestWord");
+            });
+        });
+        describe("kebabCase", () => {
+            it("should kebab case word", () => {
+                expect(kebabCase("test word")).toEqual("test-word");
+                expect(kebabCase("TestWord")).toEqual("test-word");
+                expect(kebabCase("testWord")).toEqual("test-word");
             });
         });
     });

--- a/packages/pixeloven-generators/src/generators.ts
+++ b/packages/pixeloven-generators/src/generators.ts
@@ -54,11 +54,37 @@ export const makeValidateMinLength = (min: number) => {
  * Modifiers for templates
  * @param txt
  */
+export const firstChar = (txt: string) => txt.charAt(0).toLowerCase();
 export const capitalize = (txt: string) =>
     txt.charAt(0).toUpperCase() + txt.toLowerCase().slice(1);
 export const plural = (txt: string) => `${txt}s`;
 export const upperCase = (txt: string) => txt.toUpperCase();
 export const lowerCase = (txt: string) => txt.toLowerCase();
+export const camelCase = (txt: string) => {
+    const a = txt.replace(/-/g, "- ").split(/[\s]/);
+    const b = a.map((item, index) => {
+      return index < 1 ? item.charAt(0).toLowerCase() + item.slice(1) : item;
+    });
+
+    return b.join("");
+}
+export const pascalCase = (s: string) => {
+    const a = s.replace(/-/g, "- ").split(/[\s]/);
+    const b = a.map((item, index) => {
+      return item.charAt(0).toUpperCase() + item.slice(1);
+    });
+
+    return b.join("");
+}
+export const kebabCase = (s: string) => {
+    const a = s.split(/(?=[A-Z])/);
+    const b = a.map((item, index) => {
+      return item.charAt(0).toLowerCase() + item.slice(1);
+    });
+
+    return b.join("-");
+}
+
 
 /**
  * @todo should check filesystem for serviceName, and components etc
@@ -77,6 +103,10 @@ const generator = (plop: Plop) => {
     plop.setHelper("plural", plural);
     plop.setHelper("upperCase", upperCase);
     plop.setHelper("lowerCase", lowerCase);
+    plop.setHelper("camelCase", camelCase);
+    plop.setHelper("pascalCase", pascalCase);
+    plop.setHelper("kebabCase", kebabCase);
+    plop.setHelper("firstChar", firstChar);
 
     plop.setGenerator("component", {
         actions: answers => {

--- a/packages/pixeloven-generators/src/generators.ts
+++ b/packages/pixeloven-generators/src/generators.ts
@@ -61,24 +61,24 @@ export const plural = (txt: string) => `${txt}s`;
 export const upperCase = (txt: string) => txt.toUpperCase();
 export const lowerCase = (txt: string) => txt.toLowerCase();
 export const camelCase = (txt: string) => {
-    const a = txt.replace(/-/g, "- ").split(/[\s]/);
+    const a = txt.split(/\-|[\s]/);
     const b = a.map((item, index) => {
-      return index < 1 ? item.charAt(0).toLowerCase() + item.slice(1) : item;
+      console.log(index, item);
+      return index < 1 ? item.charAt(0).toLowerCase() + item.slice(1) : item.charAt(0).toUpperCase() + item.slice(1);
     });
-
     return b.join("");
 }
-export const pascalCase = (s: string) => {
-    const a = s.replace(/-/g, "- ").split(/[\s]/);
-    const b = a.map((item, index) => {
+export const pascalCase = (txt: string) => {
+    const a = txt.split(/\-|[\s]/);
+    const b = a.map((item) => {
       return item.charAt(0).toUpperCase() + item.slice(1);
     });
 
     return b.join("");
 }
-export const kebabCase = (s: string) => {
-    const a = s.split(/(?=[A-Z])/);
-    const b = a.map((item, index) => {
+export const kebabCase = (txt: string) => {
+    const a = txt.split(/\-|[\s]|(?=[A-Z])/);
+    const b = a.map((item) => {
       return item.charAt(0).toLowerCase() + item.slice(1);
     });
 
@@ -99,6 +99,7 @@ export const kebabCase = (s: string) => {
 const componentPath = resolvePath("src/shared/components", false);
 const storePath = resolvePath("src/shared/store", false);
 const generator = (plop: Plop) => {
+    plop.setHelper("firstChar", firstChar);
     plop.setHelper("capitalize", capitalize);
     plop.setHelper("plural", plural);
     plop.setHelper("upperCase", upperCase);
@@ -106,7 +107,6 @@ const generator = (plop: Plop) => {
     plop.setHelper("camelCase", camelCase);
     plop.setHelper("pascalCase", pascalCase);
     plop.setHelper("kebabCase", kebabCase);
-    plop.setHelper("firstChar", firstChar);
 
     plop.setGenerator("component", {
         actions: answers => {

--- a/packages/pixeloven-generators/src/templates/Component/Component.test.tsx.hbs
+++ b/packages/pixeloven-generators/src/templates/Component/Component.test.tsx.hbs
@@ -19,7 +19,7 @@ describe("Shared/Components/{{capitalize (plural atomicType)}}/{{componentName}}
     it("should extend passed classes", () => {
         const wrapper = shallow(<{{componentName}} className={"test-class"} />);
 
-        expect(wrapper.hasClass("example-class")).toBe(true);
+        expect(wrapper.hasClass("{{firstChar atomicType}}-{{kebabCase componentName}}")).toBe(true);
         expect(wrapper.hasClass("test-class")).toBe(true);
     });
 });

--- a/packages/pixeloven-generators/src/templates/Component/class.Component.tsx.hbs
+++ b/packages/pixeloven-generators/src/templates/Component/class.Component.tsx.hbs
@@ -18,11 +18,11 @@ interface State {
 class {{componentName}} extends React.Component<{{componentName}}Props{{#if includeState}}, State{{/if}}> {
     public render() {
         const { className } = this.props;
-        const  {{componentName}}Classes = classNames(className, "example-class");
+        const  {{camelCase componentName}}Classes = classNames(className, "{{firstChar atomicType}}-{{kebabCase componentName}}");
         {{#if includeState}}const { exampleState } = this.state;{{/if}}
 
         return (
-            <div className={ {{componentName}}Classes }>
+            <div className={ {{camelCase componentName}}Classes }>
                 Class component{{#if includeState}} with {exampleState} state{{/if}}
             </div>
         );

--- a/packages/pixeloven-generators/src/templates/Component/function.Component.tsx.hbs
+++ b/packages/pixeloven-generators/src/templates/Component/function.Component.tsx.hbs
@@ -11,11 +11,11 @@ interface {{componentName}}Props {
 
 function {{componentName}}(props: {{componentName}}Props) {
     const { className } = props;
-    const {{componentName}}Classes = classNames(className, "example-class");
+    const {{camelCase componentName}}Classes = classNames(className, "{{firstChar atomicType}}-{{kebabCase componentName}}");
     {{#if includeState}}const [exampleState] = useState(0);{{/if}}
 
     return (
-        <div className={ {{componentName}}Classes }>
+        <div className={ {{camelCase componentName}}Classes }>
             Function component{{#if includeState}} with {exampleState} state{{/if}}
         </div>
     );


### PR DESCRIPTION
Removes the need to edit the classes variable name and class name

@ductiletoaster I got really tired of editing these so I took care of them in the generator templates.

Test by running `yarn all:bootstrap` in the project root and then run `yarn generate` in the `/examples/react-ssr-example`.