### PR TITLE
fix(#173): copy the generator templates to dist

### DIFF
--- a/packages/pixeloven/cli-addon-generators/package.json
+++ b/packages/pixeloven/cli-addon-generators/package.json
@@ -31,6 +31,7 @@
     "document": "pixeloven-tasks document:ts src",
     "lint": "yarn lint:ts",
     "lint:ts": "pixeloven-tasks lint:ts src/**/*.{ts,tsx}",
+    "postcompile": "copyfiles -u 2 src/templates/**/*.ejs dist/lib/templates",
     "pretty": "pixeloven-tasks pretty src/**/*.{ts,tsx}",
     "pretty:ts": "pixeloven-tasks pretty:ts src/**/*.{ts,tsx}",
     "precompile": "pixeloven-tasks compile:clean",


### PR DESCRIPTION
The template files weren't being copied by TS Compile, they had to be copied manually in the post compile phase.

To test:
checkout the branch, run `yarn all:clean && yarn all:bootstrap`
run `cd apps/examples/react-ssr-example`
run `yarn generate`
Use the component option and add any details you wish
Should result in generated files
Clean up by deleting the test component from the example app.