### PR TITLE
chore(#175): re-add the previous component generator features

### DIFF
--- a/packages/pixeloven/cli-addon-generators/src/extensions/createComponent.ts
+++ b/packages/pixeloven/cli-addon-generators/src/extensions/createComponent.ts
@@ -23,12 +23,16 @@ export default (toolbox: AddonGeneratorsToolbox) => {
             componentHasStyle,
         } = options;
         const { strings, template } = toolbox;
+        const className = `${strings.lowerCase(componentAtomicType.charAt(0))}-${strings.kebabCase(componentName)}`;
+        const name = `${strings.pascalCase(componentName)}`;
         const props = {
             atomicType: componentAtomicType,
+            camelName: strings.camelCase(name),
+            className,
             description: componentDescription,
             hasState: componentHasState,
             hasStyle: componentHasStyle,
-            name: componentName,
+            name,
         };
         const atomicType = strings.pluralize(
             strings.lowerCase(componentAtomicType),
@@ -36,32 +40,32 @@ export default (toolbox: AddonGeneratorsToolbox) => {
         const paradigmType = strings.lowerCase(componentParadigmType);
         template.generate({
             props,
-            target: `src/shared/components/${atomicType}/${componentName}/${componentName}.tsx`,
+            target: `src/shared/components/${atomicType}/${name}/${name}.tsx`,
             template: `component/${paradigmType}.Component.tsx.ejs`,
         });
         template.generate({
             props,
-            target: `src/shared/components/${atomicType}/${componentName}/${componentName}.scss`,
+            target: `src/shared/components/${atomicType}/${name}/${name}.scss`,
             template: `component/Component.scss.ejs`,
         });
         template.generate({
             props,
-            target: `src/shared/components/${atomicType}/${componentName}/${componentName}.stories.tsx`,
+            target: `src/shared/components/${atomicType}/${name}/${name}.stories.tsx`,
             template: `component/Component.stories.tsx.ejs`,
         });
         template.generate({
             props,
-            target: `src/shared/components/${atomicType}/${componentName}/${componentName}.test.tsx`,
+            target: `src/shared/components/${atomicType}/${name}/${name}.test.tsx`,
             template: `component/Component.test.tsx.ejs`,
         });
         template.generate({
             props,
-            target: `src/shared/components/${atomicType}/${componentName}/index.ts`,
+            target: `src/shared/components/${atomicType}/${name}/index.ts`,
             template: `component/index.ts.ejs`,
         });
         template.generate({
             props,
-            target: `src/shared/components/${atomicType}/${componentName}/README.md`,
+            target: `src/shared/components/${atomicType}/${name}/README.md`,
             template: `component/README.md.ejs`,
         });
     };

--- a/packages/pixeloven/cli-addon-generators/src/templates/component/Component.test.tsx.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/component/Component.test.tsx.ejs
@@ -17,7 +17,7 @@ describe("shared/components/<%= props.atomicType %>/<%= props.name %>", () => {
 
     it("should extend passed classes", () => {
         const wrapper = shallow(<<%= props.name %> className={"test-class"} />);
-        expect(wrapper.hasClass("example-class")).toBe(true);
-        expect(wrapper.hasClass("test-class")).toBe(true);
+        expect(wrapper.hasClass("<%= props.className %>")).toEqual(true);
+        expect(wrapper.hasClass("test-class")).toEqual(true);
     });
 });

--- a/packages/pixeloven/cli-addon-generators/src/templates/component/classical.Component.tsx.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/component/classical.Component.tsx.ejs
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import React from "react";
-<% if (props.hasStyles) { %>
+<% if (props.hasStyle) { %>
 import "./<%= props.name %>.scss";
 <% } %>
 interface <%= props.name %>Props {
@@ -14,12 +14,12 @@ interface <%= props.name %>State {
 class <%= props.name %> extends React.Component<<%= props.name %>Props<% if (props.hasState) { %>,<%= props.name %>State<% } %>> {
     public render() {
         const { className } = this.props;
-        const exampleClasses = classNames(className, "example-class");
+        const <%= props.camelName %>Classes = classNames(className, "<%= props.className %>");
         <% if (props.hasState) { %>
         const { exampleState } = this.state;
         <% } %>
         return (
-            <div className={exampleClasses}>
+            <div className={<%= props.camelName %>Classes}>
                 Function component<% if (props.hasState) { %> with {exampleState} state<% } %>
             </div>
         );

--- a/packages/pixeloven/cli-addon-generators/src/templates/component/functional.Component.tsx.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/component/functional.Component.tsx.ejs
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import React<% if (props.hasState) { %>, { useEffect, useState }<% } %> from "react";
-<% if (props.hasStyles) { %>
+<% if (props.hasStyle) { %>
 import "./<%= props.name %>.scss";
 <% } %>
 interface <%= props.name %>Props {
@@ -9,15 +9,16 @@ interface <%= props.name %>Props {
 
 function <%= props.name %>(props: <%= props.name %>Props) {
     const { className } = props;
-    const exampleClasses = classNames(className, "example-class");
+    const <%= props.camelName %>Classes = classNames(className, "<%= props.className %>");
     <% if (props.hasState) { %>
     const [isExample, setExample] = useState(false);
+
     useEffect(() => {
         console.log(`Example state changed! ${isExample}`);
     }, [isExample]);
     <% } %>
     return (
-        <div className={exampleClasses}>
+        <div className={<%= props.camelName %>Classes}>
             Function component<% if (props.hasState) { %> with <a onClick={() => setExample(!isExample)}>example state</a> {isExample ? "on" : "off"}<% } %>
         </div>
     );


### PR DESCRIPTION
Reduces the amount of work users have to do to customize the template files generated by pixeloven