### PR TITLE
fix: upgrade min node engine to fix azure pipeline test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,6 @@ stages:
     - task: NodeTool@0
       inputs:
         versionSpec: $(node_version)
-    - script: npm install --global lerna
     # @todo we should find a better way
     - script: yarn install --production=false
 
@@ -24,7 +23,6 @@ stages:
   jobs:
   - job: compile
     steps:
-    - script: npm install --global lerna
     - script: yarn pixeloven:compile
 
 - stage: check_pixeloven

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,7 @@ stages:
     - task: NodeTool@0
       inputs:
         versionSpec: $(node_version)
-    - script: |
-          yarn global lerna
-        displayName: "Install Lerna"
+    - script: yarn global lerna
     # @todo we should find a better way
     - script: yarn install --production=false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ stages:
     - task: NodeTool@0
       inputs:
         versionSpec: $(node_version)
-    - script: yarn global lerna
+    - script: yarn global add lerna
     # @todo we should find a better way
     - script: yarn install --production=false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ stages:
     - task: NodeTool@0
       inputs:
         versionSpec: $(node_version)
-    - script: yarn global add lerna
+    - script: npm install --global lerna
     # @todo we should find a better way
     - script: yarn install --production=false
 
@@ -24,6 +24,7 @@ stages:
   jobs:
   - job: compile
     steps:
+    - script: npm install --global lerna
     - script: yarn pixeloven:compile
 
 - stage: check_pixeloven

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,33 +12,36 @@ stages:
         node_10_x:
           node_version: 10.x
     steps:
-    - task: NodeTool@0 
+    - task: NodeTool@0
       inputs:
         versionSpec: $(node_version)
+    - script: |
+          yarn global lerna
+        displayName: "Install Lerna"
     # @todo we should find a better way
     - script: yarn install --production=false
 
 - stage: compile_pixeloven
   displayName: Compile PixelOven packages
   jobs:
-  - job: compile 
+  - job: compile
     steps:
     - script: yarn pixeloven:compile
 
 - stage: check_pixeloven
   displayName: Check quality of PixelOven packages
   jobs:
-  - job: lint 
+  - job: lint
     steps:
     - script: yarn pixeloven:lint
-  - job: test 
+  - job: test
     steps:
     - script: yarn pixeloven:test
 
 - stage: build_pixeloven
   displayName: Build PixelOven apps
   jobs:
-  - job: build 
+  - job: build
     steps:
     - script: yarn pixeloven:build
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=10.0.0",
     "yarn": ">=1.0.0"
   },
   "workspaces": [


### PR DESCRIPTION
This should fix our failing Azure pipeline. Support for v8 ends in two months anyway. 

https://nodejs.org/en/about/releases/