### PR TITLE
chore: create the pixeloven copy command

### DIFF
--- a/packages/examples/component-library-example/package.json
+++ b/packages/examples/component-library-example/package.json
@@ -33,7 +33,7 @@
     "lint": "yarn run lint:ts",
     "lint:ts": "pixeloven lint ts 'src/**/*.{ts,tsx}'",
     "precompile": "pixeloven delete dist",
-    "postcompile": "copyfiles -u 1 'src/**/*.{scss,svg}' ./dist/lib",
+    "postcompile": "pixeloven copy assets",
     "precommit": "lint-staged",
     "predocument": "pixeloven delete docs",
     "pretest": "pixeloven delete coverage",

--- a/packages/pixeloven/cli/src/commands/copy.test.ts
+++ b/packages/pixeloven/cli/src/commands/copy.test.ts
@@ -1,0 +1,58 @@
+import { cli, Mock, Sandbox } from "../testing";
+import copyModule from "./copy";
+
+const mockFileCopy = Mock.filesystem.expects("copy");
+const mockPrintError = Mock.print.expects("error");
+const mockPrintInfo = Mock.print.expects("info");
+const mockPrintSuccess = Mock.print.expects("success");
+
+describe("@pixeloven/cli", () => {
+    describe("commands", () => {
+        describe("copy", () => {
+            afterAll(() => {
+                Sandbox.restore();
+                mockFileCopy.restore();
+                mockPrintError.restore();
+                mockPrintInfo.restore();
+                mockPrintSuccess.restore();
+            });
+            afterEach(() => {
+                Sandbox.reset();
+                mockFileCopy.reset();
+                mockPrintError.reset();
+                mockPrintInfo.reset();
+                mockPrintSuccess.reset();
+            });
+            it("should contains required props", () => {
+                expect(copyModule.alias).toEqual(["--copy"]);
+                expect(copyModule.name).toEqual("copy");
+                expect(typeof copyModule.run).toEqual("function");
+            });
+            it("should print error", async () => {
+                const context = await cli.run("copy");
+                expect(mockFileCopy.callCount).toEqual(0);
+                expect(mockPrintError.callCount).toEqual(1);
+                expect(mockPrintInfo.callCount).toEqual(1);
+                expect(context.commandName).toEqual("copy");
+            });
+            it("should copy scss", async () => {
+                const context = await cli.run("copy scss");
+                expect(mockFileCopy.callCount).toEqual(1);
+                expect(mockPrintSuccess.callCount).toEqual(1);
+                expect(context.commandName).toEqual("copy");
+            });
+            it("should copy svg", async () => {
+                const context = await cli.run("copy svg");
+                expect(mockFileCopy.callCount).toEqual(1);
+                expect(mockPrintSuccess.callCount).toEqual(1);
+                expect(context.commandName).toEqual("copy");
+            });
+            it("should copy assets", async () => {
+                const context = await cli.run("copy assets");
+                expect(mockFileCopy.callCount).toEqual(1);
+                expect(mockPrintSuccess.callCount).toEqual(1);
+                expect(context.commandName).toEqual("copy");
+            });
+        });
+    });
+});

--- a/packages/pixeloven/cli/src/commands/copy.ts
+++ b/packages/pixeloven/cli/src/commands/copy.ts
@@ -1,0 +1,36 @@
+import { PixelOvenToolbox } from "../types";
+
+export default {
+    alias: ["--copy"],
+    name: "copy",
+    run: async (toolbox: PixelOvenToolbox) => {
+        const { filesystem, parameters, pixelOven, print } = toolbox;
+
+        switch (parameters.first) {
+            case "scss":
+                filesystem.copy("src", "dist/lib", {
+                    matching: "**/*.scss",
+                    overwrite: true,
+                });
+                print.success(`Successfully copied scss files to dist`);
+                break;
+            case "svg":
+                filesystem.copy("src", "dist/lib", {
+                    matching: "**/*.svg",
+                    overwrite: true,
+                });
+                print.success(`Successfully copied svg files to dist`);
+                break;
+            case "assets":
+                filesystem.copy("src", "dist/lib", {
+                    matching: "**/*.{scss,svg}",
+                    overwrite: true,
+                });
+                print.success(`Successfully copied assets to dist`);
+                break;
+            default:
+                pixelOven.invalidArgument();
+                break;
+        }
+    },
+};


### PR DESCRIPTION
Creates a pixeloven copy command for copying component assets. 

For testing:
1. checkout branch
2. run `yarn all:clean && yarn all:bootstrap`
3. cd to `packages/examples/component-library-example`
4. run `yarn compile`
5. check `/dist/lib`,  ts files should be transpiled to js, and svg and scss files should be copied over.