### PR TITLE
feat: create the package generator

### DIFF
--- a/packages/pixeloven/cli-addon-generators/src/commands/generate.ts
+++ b/packages/pixeloven/cli-addon-generators/src/commands/generate.ts
@@ -8,6 +8,7 @@ import {
     AtomicDesignType,
     CreateComponentOptions,
     CreateOptions,
+    CreatePackageOptions,
     GeneratorType,
     ProgrammingParadigm,
 } from "../types";
@@ -20,7 +21,13 @@ export default {
     alias: ["--generate", "-g"],
     name: "generate",
     run: async (toolbox: AddonGeneratorsToolbox) => {
-        const { createComponent, print, pixelOven, prompt } = toolbox;
+        const {
+            createComponent,
+            createPackage,
+            print,
+            pixelOven,
+            prompt,
+        } = toolbox;
         // todo create generator for library
         // todo crete generator for addon
         // todo crete generator for state
@@ -102,6 +109,57 @@ export default {
                 validate: Validation.minLength(1),
             },
         ];
+        const askCreatePackageQuestions = [
+            {
+                message: "What is the name of the new package?",
+                name: "packageName",
+                type: "input",
+                validate: Validation.minLength(1),
+            },
+            {
+                message:
+                    "Provide a package namespace if necessary (leave blank if not required):",
+                name: "packageNameSpace",
+                type: "input",
+            },
+            {
+                message: "Provide a brief description of the package:",
+                name: "packageDescription",
+                type: "input",
+                validate: Validation.minLength(1),
+            },
+            {
+                message: "Provide a license type for the package:",
+                name: "packageLicense",
+                type: "input",
+                validate: Validation.minLength(1),
+            },
+            {
+                message: "Provide the author name:",
+                name: "packageAuthorName",
+                type: "input",
+                validate: Validation.minLength(1),
+            },
+            {
+                message: "Provide the author email:",
+                name: "packageAuthorEmail",
+                type: "input",
+                validate: Validation.minLength(1),
+            },
+            {
+                message:
+                    "Provide a private registery if necessary(leave blank if not required):",
+                name: "packageRegistry",
+                type: "input",
+            },
+            {
+                message:
+                    "Provide an initial version to publish the package with:",
+                name: "packageVersion",
+                type: "input",
+                validate: Validation.minLength(1),
+            },
+        ];
         const { generatorType } = (await prompt.ask<CreateOptions>(
             askCreateQuestions,
         )) as any;
@@ -118,7 +176,10 @@ export default {
                 break;
             }
             case "Package": {
-                print.info("Coming Soon");
+                const options = (await prompt.ask<CreatePackageOptions>(
+                    askCreatePackageQuestions,
+                )) as any;
+                createPackage(options);
                 break;
             }
             default: {

--- a/packages/pixeloven/cli-addon-generators/src/extensions/createComponent.ts
+++ b/packages/pixeloven/cli-addon-generators/src/extensions/createComponent.ts
@@ -1,17 +1,5 @@
 import { AddonGeneratorsToolbox, CreateComponentOptions } from "../types";
 
-/**
- * @todo can we use any of this https://github.com/glenjamin/ultimate-hot-reloading-example
- * @todo bring this back https://github.com/gaearon/react-hot-loader
- * @todo FIX client onDone runs twice which means we are compile an extra time :(
- * @todo 1) Create CLI options for --open (auto-open)
- * @todo 2) Create CLI options for --choose-port (auto-choose-port)
- * @todo 3) Create CLI options for --machine (host|docker|virtual)
- *
- * @todo 4) Make logging to json would be nice
- *
- * @todo Make build and dev-server configurable through CLI.
- */
 export default (toolbox: AddonGeneratorsToolbox) => {
     const createComponent = async (options: CreateComponentOptions) => {
         const {
@@ -71,8 +59,5 @@ export default (toolbox: AddonGeneratorsToolbox) => {
             template: `component/README.md.ejs`,
         });
     };
-    /**
-     * @todo namespace this a little better... like .create .modify etc
-     */
     toolbox.createComponent = createComponent;
 };

--- a/packages/pixeloven/cli-addon-generators/src/extensions/createPackage.ts
+++ b/packages/pixeloven/cli-addon-generators/src/extensions/createPackage.ts
@@ -1,0 +1,99 @@
+import { AddonGeneratorsToolbox, CreatePackageOptions } from "../types";
+
+export default (toolbox: AddonGeneratorsToolbox) => {
+    const createPackage = async (options: CreatePackageOptions) => {
+        const {
+            packageAuthorEmail,
+            packageAuthorName,
+            packageDescription,
+            packageLicense,
+            packageName,
+            packageNameSpace,
+            packageRegistry,
+            packageVersion,
+        } = options;
+        const { template } = toolbox;
+        const name = packageName;
+        const props = {
+            authorEmail: packageAuthorEmail,
+            authorName: packageAuthorName,
+            description: packageDescription,
+            license: packageLicense,
+            name,
+            nameSpace: packageNameSpace,
+            registry: packageRegistry,
+            version: packageVersion,
+        };
+        template.generate({
+            props,
+            target: `packages/${name}/jest.json`,
+            template: "package/jest.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/package.json`,
+            template: "package/package.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/prettier.json`,
+            template: "package/prettier.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/README.md`,
+            template: "package/README.md.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/stylelint.json`,
+            template: "package/stylelint.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/tsconfig.json`,
+            template: "package/tsconfig.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/tslint.json`,
+            template: "package/tslint.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/typedoc.json`,
+            template: "package/typedoc.json.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/src/constants.ts`,
+            template: "package/constants.ts.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/src/index.ts`,
+            template: "package/index.ts.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/src/modules.d.ts`,
+            template: "package/modules.d.ts.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/src/types.ts`,
+            template: "package/types.ts.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/src/_mocks_/files.ts`,
+            template: "package/files.ts.ejs",
+        });
+        template.generate({
+            props,
+            target: `packages/${name}/src/_mocks_/styles.ts`,
+            template: "package/styles.ts.ejs",
+        });
+    };
+    toolbox.createPackage = createPackage;
+};

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/README.md.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/README.md.ejs
@@ -1,0 +1,29 @@
+<% if (props.nameSpace && props.nameSpace.length > 0) { -%>
+# <%= props.nameSpace %>/packages-<%= props.name %>
+<% } else { -%>
+# <%= props.name %>
+<% } -%>
+
+<%= props.description %>
+
+## Insall
+
+Using npm:
+
+```sh
+<% if (props.nameSpace && props.nameSpace.length > 0) { -%>
+npm install --save <%= props.nameSpace %>/packages-<%= props.name %>
+<% } else { -%>
+npm install --save <%= props.name %>
+<% } -%>
+```
+
+or using yarn:
+
+```sh
+<% if (props.nameSpace && props.nameSpace.length > 0) { -%>
+yarn add <%= props.nameSpace %>/packages-<%= props.name %>
+<% } else { -%>
+yarn add <%= props.name %>
+<% } -%>
+```

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/constants.ts.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/constants.ts.ejs
@@ -1,0 +1,4 @@
+/**
+ * Register package constants here
+ */
+

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/files.ts.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/files.ts.ejs
@@ -1,0 +1,5 @@
+/**
+ * Prevents issues with Jest when test with assets. However it also hides these assets and stops any visual tests.
+ * @description https://github.com/facebook/jest/issues/3094
+ */
+export default "test-file-stub";

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/index.ts.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/index.ts.ejs
@@ -1,0 +1,6 @@
+/**
+ * Register package components here
+ */
+
+// export * from "./constants";
+// export * from "./types";

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/jest.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/jest.json.ejs
@@ -1,0 +1,52 @@
+{
+  "bail": true,
+  "verbose": true,
+  "preset": "ts-jest",
+  "coveragePathIgnorePatterns": [
+    "<rootDir>/node_modules/"
+  ],
+  "coverageThreshold": {
+    "global": {
+      "branches": 90,
+      "functions": 90,
+      "lines": 90,
+      "statements": 90
+    }
+  },
+  "collectCoverageFrom": [
+    "<rootDir>/src/**/*.{js,jsx,ts,tsx}",
+    "!<rootDir>/src/**/*.stories.{js,jsx,ts,tsx}",
+    "!<rootDir>/src/**/styles/**",
+    "!**/node_modules/**"
+  ],
+  "testMatch": [
+    "<rootDir>/test/**/*.(j|t)s?(x)",
+    "<rootDir>/src/**/?(*.)(spec|test).(j|t)s?(x)"
+  ],
+  "testPathIgnorePatterns": [
+    "<rootDir>/node_modules/"
+  ],
+  "testEnvironment": "jsdom",
+  "testURL": "http://localhost",
+  "transform": {
+    "^.+\\.(js|jsx)$": "babel-jest",
+    "^.+\\.(ts|tsx)$": "ts-jest"
+  },
+  "transformIgnorePatterns": [
+    "<rootDir>/node_modules/"
+  ],
+  "moduleDirectories": [
+    "node_modules"
+  ],
+  "moduleNameMapper": {
+    ".+\\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/__mocks__/files.ts",
+    ".+\\.(css|styl|less|sass|scss)$": "<rootDir>/src/__mocks__/styles.ts"
+  },
+  "moduleFileExtensions": [
+    "js",
+    "jsx",
+    "ts",
+    "tsx"
+  ],
+  "maxConcurrency": 2
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/modules.d.ts.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/modules.d.ts.ejs
@@ -1,0 +1,15 @@
+/**
+ * Declare file formats not covered by typescript automatically
+ */
+declare module "*.ico";
+declare module "*.svg";
+declare module "*.png";
+declare module "*.jpg";
+declare module "*.md";
+
+/**
+ * Declare packages not explicitly defined
+ * @description Consult DefinitelyTyped before declaring below
+ * http://definitelytyped.org/
+ */
+declare module "storybook-readme";

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/package.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/package.json.ejs
@@ -1,0 +1,53 @@
+{
+  <%_ if (props.nameSpace && props.nameSpace.length > 0) { -%>
+  "name": "<%= props.nameSpace %>/packages-<%= props.name %>",
+  <%_ } else { -%>
+  "name": "<%= props.name %>",
+  <%_ } -%>
+  "version": "<%= props.version %>",
+  "description": "<%= props.description %>",
+  "author": "<%= props.authorName %> <<%= props.authorEmail %>>",
+  "license": "<%= props.license %>",
+  <%_ if (props.registry) { -%>
+  "publishConfig": {
+    "access": "private",
+    "registry": "<%= props.registry %>"
+  },
+  <%_ } -%>
+  "main": "dist/lib/index.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "compile": "pixeloven compile ts",
+    "document": "pixeloven document ts ./src",
+    "generate": "pixeloven generate",
+    "lint": "yarn lint:ts && yarn lint:scss",
+    "lint:ts": "pixeloven lint ts ./src/**/*.{ts,tsx}",
+    "lint:scss": "pixeloven lint scss ./src/**/*.scss",
+    "pretty": "yarn pretty:ts && yarn pretty:scss",
+    "pretty:ts": "pixeloven pretty ts ./src/**/*.{ts,tsx}",
+    "pretty:scss": "pixeloven pretty scss ./src/**/*.scss",
+    "test": "pixeloven test --color --coverage",
+    "test:ci": "pixeloven test --ci",
+    "test:watch": "pixeloven test watch",
+    "start:story": "pixeloven story start",
+    "precommit": "lint-staged",
+    "predocument": "pixeloven delete docs",
+    "pretest": "pixeloven delete coverage",
+    "postcompile": "pixeloven copy assets"
+  },
+  "lint-staged": {
+    "src/**/*.{scss}": [
+      "yarn pixeloven pretty scss",
+      "yarn pixeloven lint scss",
+      "git add"
+    ],
+    "src/**/*.{ts,tsx}": [
+      "yarn pixeloven pretty ts",
+      "yarn pixeloven lint ts",
+      "git add"
+    ]
+  }
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/prettier.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/prettier.json.ejs
@@ -1,0 +1,6 @@
+{
+    "bracketSpacing": false,
+    "printWidth": 120,
+    "trailingComma": "all",
+    "tabWidth": 4
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/stylelint.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/stylelint.json.ejs
@@ -1,0 +1,3 @@
+{
+    "extends": "stylelint-config-recommended-scss"
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/styles.ts.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/styles.ts.ejs
@@ -1,0 +1,5 @@
+/**
+ * Prevents issues with Jest when test with assets. However it also hids these assets and stops any visual tests.
+ * @description https://github.com/facebook/jest/issues/3094
+ */
+export default {};

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/tsconfig.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/tsconfig.json.ejs
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+      "declaration": true,
+      "declarationDir": "./dist/types",
+      "outDir": "./dist/lib",
+      "rootDir": "./src",
+      "skipLibCheck": true
+  }
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/tslint.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/tslint.json.ejs
@@ -1,0 +1,33 @@
+{
+  "defaultSeverity": "error",
+  "linterOptions": {
+    "exclude": [
+      "ansible",
+      "coverage",
+      "dist",
+      "docs",
+      "node_modules",
+      "storage",
+      "terraform"
+    ]
+  },
+  "extends": [
+    "tslint:latest",
+    "tslint-config-prettier",
+    "tslint-eslint-rules",
+    "tslint-react"
+  ],
+  "rules": {
+    "arrow-parens": false,
+    "jsx-no-multiline": false,
+    "jsx-no-multiline-js": false,
+    "jsx-wrap-multiline": false,
+    "jsx-no-lambda": false,
+    "interface-name" : false,
+    "no-implicit-dependencies": false,
+    "no-submodule-imports": false,
+    "no-console": false,
+    "no-any": true,
+    "no-null-keyword": true
+  }
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/typedoc.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/typedoc.json.ejs
@@ -1,0 +1,13 @@
+{
+    <%_ if (props.nameSpace && props.nameSpace.length > 0) { -%>
+    "name": "<%= props.nameSpace %>/packages-<%= props.name %>",
+    <%_ } else { -%>
+    "name": "<%= props.name %>",
+    <%_} -%>
+    "target": "es5",
+    "out": "docs",
+    "exclude": "*.{story,test}.{ts,tsx}",
+    "externalPattern": "**/node_modules/**",
+    "excludeExternals": true,
+    "includeDeclarations": false
+}

--- a/packages/pixeloven/cli-addon-generators/src/templates/package/types.ts.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/types.ts.ejs
@@ -1,0 +1,4 @@
+/**
+ * Register package types here
+ */
+

--- a/packages/pixeloven/cli-addon-generators/src/types.ts
+++ b/packages/pixeloven/cli-addon-generators/src/types.ts
@@ -48,6 +48,22 @@ export type CreateComponentExtension = (
     options: CreateComponentOptions,
 ) => Promise<void>;
 
+export interface CreatePackageOptions {
+    packageAuthorEmail: string;
+    packageAuthorName: string;
+    packageDescription: string;
+    packageLicense: string;
+    packageName: string;
+    packageNameSpace?: string;
+    packageRegistry?: string;
+    packageVersion: number | string;
+}
+
+export type CreatePackageExtension = (
+    options: CreatePackageOptions,
+) => Promise<void>;
+
 export interface AddonGeneratorsToolbox extends PixelOvenToolbox {
     createComponent: CreateComponentExtension;
+    createPackage: CreatePackageExtension;
 }


### PR DESCRIPTION
To test, run `yarn pixeloven:compile` from the root, then navigate to `apps/examples/react-ssr-example` and run `yarn generate`. Choose `Package` from the available options, then follow the prompts. You should now have a package within the app (make sure you delete it so you don't end up with conflicts later).