### PR TITLE
fix: add dep requirements to the generated package template

### DIFF
--- a/packages/pixeloven/cli-addon-generators/src/templates/package/package.json.ejs
+++ b/packages/pixeloven/cli-addon-generators/src/templates/package/package.json.ejs
@@ -19,6 +19,26 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "@types/classnames": "^2.2.9",
+    "@types/node": "^13.1.4",
+    "@types/react": "^16.9.17",
+    "@types/react-dom": "^16.9.4",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
+  },
+  "devDependencies": {
+    "@pixeloven/cli": "^6.0.0-beta.22",
+    "@pixeloven/cli-addon-generators": "^6.0.0-beta.22",
+    "@pixeloven/cli-addon-storybook": "^6.0.0-beta.23",
+    "@pixeloven/cli-addon-webpack": "^6.0.0-beta.23",
+    "@types/enzyme": "^3.10.4",
+    "@types/enzyme-adapter-react-16": "^1.0.5",
+    "@types/sinon": "^7.5.1",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
+    "sinon": "^8.0.4"
+  },
   "scripts": {
     "compile": "pixeloven compile ts",
     "document": "pixeloven document ts ./src",


### PR DESCRIPTION
I forgot to include any of the dependencies for packages that are generated. 