### PR TITLE
WIP: feat: update storybook to support running stories in multiple paths

### DIFF
--- a/packages/pixeloven-storybook/config/src/config.ts
+++ b/packages/pixeloven-storybook/config/src/config.ts
@@ -45,7 +45,7 @@ addParameters({
  * Stories loader
  */
 /* tslint:disable no-string-literal */
-const req = require["context"]("@src", true, /.stories.[jt]sx?$/);
+const req = require["context"]("@cwd", true, /.stories.[jt]sx?$/);
 function loadStories() {
     req.keys().forEach(req);
 }

--- a/packages/pixeloven-storybook/config/src/webpack.config.ts
+++ b/packages/pixeloven-storybook/config/src/webpack.config.ts
@@ -57,9 +57,12 @@ async function getConfig(options: Options) {
     if (config.resolve) {
         // Aliases
         if (config.resolve.alias) {
+            // change to @cwd so that stories locally run from the working directory and on jenkins from root
+            config.resolve.alias["@cwd"] = process.cwd();
             config.resolve.alias["@src"] = resolveSourceRoot();
         } else {
             config.resolve.alias = {
+                "@cwd": process.cwd(),
                 "@src": resolveSourceRoot(),
             };
         }


### PR DESCRIPTION
It attempts to run just fine, but chokes when it hits components (or any file really) with `@shared` imports. Run it from the example app directory and it works fine, run it from the overall `apps` directory and it fails.