### PR TITLE
Add static asset path option

### DIFF
--- a/packages/pixeloven-webpack/compiler/src/index.ts
+++ b/packages/pixeloven-webpack/compiler/src/index.ts
@@ -15,6 +15,7 @@ const defaultCompilerOptions: Options = {
     profiling: false,
     publicPath: "/",
     sourceMap: false,
+    staticAssetPath: "static",
     stats: {
         enabled: false,
         host: "localhost",

--- a/packages/pixeloven-webpack/config/src/helpers/shared.ts
+++ b/packages/pixeloven-webpack/config/src/helpers/shared.ts
@@ -169,13 +169,13 @@ export function getSetup(options: Options) {
         return ifClient(
             {
                 chunkFilename: ifProduction(
-                    "static/js/[name].[contenthash].js",
-                    "static/js/[name].[hash].js",
+                    `${options.staticAssetPath}/js/[name].[contenthash].js`,
+                    `${options.staticAssetPath}/js/[name].[hash].js`,
                 ),
                 devtoolModuleFilenameTemplate,
                 filename: ifProduction(
-                    "static/js/[name].[contenthash].js",
-                    "static/js/[name].[hash].js",
+                    `${options.staticAssetPath}/js/[name].[contenthash].js`,
+                    `${options.staticAssetPath}/js/[name].[hash].js`,
                 ),
                 path: resolvePath(
                     path.normalize(`${options.outputPath}/public`),
@@ -211,8 +211,8 @@ export function getSetup(options: Options) {
             options: {
                 emitFile: ifClient(),
                 name: ifProduction(
-                    "static/media/[name].[contenthash].[ext]",
-                    "static/media/[name].[hash].[ext]",
+                    `${options.staticAssetPath}/media/[name].[contenthash].[ext]`,
+                    `${options.staticAssetPath}/media/[name].[hash].[ext]`,
                 ),
             },
         };

--- a/packages/pixeloven-webpack/config/src/index.ts
+++ b/packages/pixeloven-webpack/config/src/index.ts
@@ -135,12 +135,12 @@ function getConfig(options: Options) {
              */
             new MiniCssExtractPlugin({
                 chunkFilename: ifProduction(
-                    "static/css/[name].[contenthash].css",
-                    "static/css/[name].[hash].css",
+                    `${options.staticAssetPath}/css/[name].[contenthash].css`,
+                    `${options.staticAssetPath}/css/[name].[hash].css`,
                 ),
                 filename: ifProduction(
-                    "static/css/[name].[contenthash].css",
-                    "static/css/[name].[hash].css",
+                    `${options.staticAssetPath}/css/[name].[contenthash].css`,
+                    `${options.staticAssetPath}/css/[name].[hash].css`,
                 ),
             }),
             getPluginBundleAnalyzer(options.stats),

--- a/packages/pixeloven-webpack/config/src/types.ts
+++ b/packages/pixeloven-webpack/config/src/types.ts
@@ -12,6 +12,7 @@ export interface Options {
     entry: string;
     mode: Mode;
     name: Name;
+    staticAssetPath: string;
     outputPath: string;
     profiling: boolean;
     publicPath: string;

--- a/packages/pixeloven/cli-addon-webpack/src/commands/webpack.ts
+++ b/packages/pixeloven/cli-addon-webpack/src/commands/webpack.ts
@@ -67,6 +67,7 @@ export default {
             protocol,
             server,
             sourceMap,
+            staticAssetPath,
             stats,
             statsDir,
             statsHost,
@@ -109,6 +110,7 @@ export default {
                 profiling: profile,
                 publicPath: path,
                 sourceMap,
+                staticAssetPath,
                 stats: {
                     enabled: stats || false,
                     host: statsHost || "localhost",

--- a/packages/pixeloven/cli-addon-webpack/src/types.ts
+++ b/packages/pixeloven/cli-addon-webpack/src/types.ts
@@ -41,6 +41,8 @@ export enum WebpackExecutionOptionTypes {
     "protocol" = "protocol",
     "profile" = "profile",
     "server" = "server",
+    "static-asset-path" = "static-asset-path",
+    "staticAssetPath" = "staticAssetPath",
     "stats" = "stats",
     "stats-dir" = "stats-dir",
     "statsDir" = "statsDir",


### PR DESCRIPTION
With this PR, we will be able to namespace the assets files by providing the option --static-asset-path:

For example: pixeloven webpack start --client ./src/client/index.tsx --server ./src/server/index.ts --allow-externals --development --source-map --host localhost --path / --port 8080 --protocol http --static-asset-path lol/static

<img width="1680" alt="Screen Shot 2020-01-31 at 10 16 23 PM" src="https://user-images.githubusercontent.com/679714/73588014-4bff2c80-4478-11ea-86cb-6d30e825fb42.png">

<img width="942" alt="Screen Shot 2020-01-31 at 10 15 24 PM" src="https://user-images.githubusercontent.com/679714/73588019-59b4b200-4478-11ea-8d8f-3fd1b26d7baf.png">
