### PR TITLE
chore: add js task to linter

### DIFF
--- a/packages/pixeloven/cli/src/commands/lint.test.ts
+++ b/packages/pixeloven/cli/src/commands/lint.test.ts
@@ -54,7 +54,7 @@ describe("@pixeloven/cli", () => {
                 expect(Stub.process.exit.called).toEqual(true);
                 expect(Stub.process.exit.calledWithExactly(1)).toEqual(true);
             });
-            it("should warn if tslint.json is missing and succeed linting ts/tsx", async () => {
+            it("should warn if tslint.json is missing and succeed linting ts", async () => {
                 Mock.core.expects("resolvePath").returns(false);
                 Stub.system.spawn.resolves({
                     status: 0,
@@ -67,12 +67,48 @@ describe("@pixeloven/cli", () => {
                 expect(Stub.process.exit.calledOnce).toEqual(true);
                 expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
             });
-            it("should succeed linting ts/tsx with tslint.json", async () => {
+            it("should succeed linting ts with tslint.json", async () => {
                 Mock.core.expects("resolvePath").returns(true);
                 Stub.system.spawn.resolves({
                     status: 0,
                 });
                 const context = await cli.run("lint ts");
+                expect(context.commandName).toEqual("lint");
+                expect(Stub.system.spawn.calledOnce).toEqual(true);
+                expect(Stub.print.success.calledOnce).toEqual(true);
+                expect(Stub.process.exit.calledOnce).toEqual(true);
+                expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
+            });
+            it("should succeed linting tsx with tslint.json", async () => {
+                Mock.core.expects("resolvePath").returns(true);
+                Stub.system.spawn.resolves({
+                    status: 0,
+                });
+                const context = await cli.run("lint tsx");
+                expect(context.commandName).toEqual("lint");
+                expect(Stub.system.spawn.calledOnce).toEqual(true);
+                expect(Stub.print.success.calledOnce).toEqual(true);
+                expect(Stub.process.exit.calledOnce).toEqual(true);
+                expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
+            });
+            it("should succeed linting js with tslint.json", async () => {
+                Mock.core.expects("resolvePath").returns(true);
+                Stub.system.spawn.resolves({
+                    status: 0,
+                });
+                const context = await cli.run("lint js");
+                expect(context.commandName).toEqual("lint");
+                expect(Stub.system.spawn.calledOnce).toEqual(true);
+                expect(Stub.print.success.calledOnce).toEqual(true);
+                expect(Stub.process.exit.calledOnce).toEqual(true);
+                expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
+            });
+            it("should succeed linting jsx with tslint.json", async () => {
+                Mock.core.expects("resolvePath").returns(true);
+                Stub.system.spawn.resolves({
+                    status: 0,
+                });
+                const context = await cli.run("lint jsx");
                 expect(context.commandName).toEqual("lint");
                 expect(Stub.system.spawn.calledOnce).toEqual(true);
                 expect(Stub.print.success.calledOnce).toEqual(true);

--- a/packages/pixeloven/cli/src/commands/lint.ts
+++ b/packages/pixeloven/cli/src/commands/lint.ts
@@ -1,5 +1,7 @@
 import { ErrorCode, PixelOvenToolbox } from "../types";
 
+const availableTasksString = `Available tasks are "css", "scss", "js", "jsx", "ts", or "tsx".`;
+
 export default {
     name: "lint",
     run: async (context: PixelOvenToolbox) => {
@@ -9,7 +11,7 @@ export default {
 
         if (!task) {
             print.error(`Missing task`);
-            print.info(`Available  tasks are "css", "scss", "ts", or "tsx".`);
+            print.info(availableTasksString);
             statusCode = ErrorCode.MissingTask;
         } else {
             const argList = pixelOven.getArgList(task, parameters, {
@@ -23,6 +25,8 @@ export default {
                     statusCode = results.status;
                     break;
                 }
+                case "js":
+                case "jsx":
                 case "ts":
                 case "tsx": {
                     const results = await tsLint(argList);
@@ -30,10 +34,8 @@ export default {
                     break;
                 }
                 default: {
-                    print.error(`Invalid argument ${task}`);
-                    print.info(
-                        `Available Lint tasks are "css", "scss", "ts", or "tsx".`,
-                    );
+                    print.error(`Invalid task: ${task}`);
+                    print.info(availableTasksString);
                     statusCode = ErrorCode.InvalidArgument;
                     break;
                 }


### PR DESCRIPTION
The test coverage dropped so I split up the tests for each task to make sure we cover all the conditions for the switch statement.