### PR TITLE
feat: add webpack support for devtool sourcemap options

### DIFF
--- a/apps/examples/ssr/package.json
+++ b/apps/examples/ssr/package.json
@@ -41,7 +41,7 @@
         "node": "8.x || 9.x || 10.x"
     },
     "scripts": {
-        "build:development": "pixeloven webpack build --client ./src/client/index.tsx --server ./src/server/index.ts --allow-externals --stats --source-map --path /",
+        "build:development": "pixeloven webpack build --client ./src/client/index.tsx --server ./src/server/index.ts --allow-externals --stats --source-map=source-map --path /",
         "build:production": "pixeloven webpack build --client ./src/client/index.tsx --server ./src/server/index.ts --allow-externals --path /",
         "build:story": "pixeloven story build",
         "document": "pixeloven document ts ./src",
@@ -56,7 +56,7 @@
         "precommit": "lint-staged",
         "predocument": "pixeloven delete docs",
         "pretest": "pixeloven delete coverage",
-        "start:development": "pixeloven webpack start --client ./src/client/index.tsx --server ./src/server/index.ts --allow-externals --development --source-map --host localhost --path / --port 8080 --protocol http",
+        "start:development": "pixeloven webpack start --client ./src/client/index.tsx --server ./src/server/index.ts --allow-externals --development --source-map=source-map --host localhost --path / --port 8080 --protocol http",
         "start:production": "NODE_ENV=production node ./dist/server.js",
         "start:story": "pixeloven story start",
         "test": "pixeloven test --color --coverage",

--- a/packages/pixeloven-webpack/compiler/src/index.ts
+++ b/packages/pixeloven-webpack/compiler/src/index.ts
@@ -15,7 +15,7 @@ const defaultCompilerOptions: Options = {
     outputPath: "./dist",
     profiling: false,
     publicPath: "/",
-    sourceMap: false,
+    sourceMap: "eval-source-map",
     staticAssetPath: "static",
     stats: {
         enabled: false,

--- a/packages/pixeloven-webpack/compiler/src/index.ts
+++ b/packages/pixeloven-webpack/compiler/src/index.ts
@@ -15,7 +15,7 @@ const defaultCompilerOptions: Options = {
     outputPath: "./dist",
     profiling: false,
     publicPath: "/",
-    sourceMap: "eval-source-map",
+    sourceMap: false,
     staticAssetPath: "static",
     stats: {
         enabled: false,

--- a/packages/pixeloven-webpack/config/src/helpers/shared.ts
+++ b/packages/pixeloven-webpack/config/src/helpers/shared.ts
@@ -17,6 +17,7 @@ import {
     Options as WebpackOptions,
     Resolve,
     RuleSetRule,
+    SourceMapDevToolPlugin,
 } from "webpack";
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import webpackNodeExternals from "webpack-node-externals";
@@ -117,6 +118,10 @@ export function getSetup(options: Options) {
                             },
                         }),
                         new OptimizeCSSAssetsPlugin(),
+                        new SourceMapDevToolPlugin({
+                            filename: 'sourcemaps/[file].map',
+                            exclude: ['vendor.js'],
+                        })
                     ],
                     [],
                 ),

--- a/packages/pixeloven-webpack/config/src/helpers/shared.ts
+++ b/packages/pixeloven-webpack/config/src/helpers/shared.ts
@@ -17,7 +17,6 @@ import {
     Options as WebpackOptions,
     Resolve,
     RuleSetRule,
-    SourceMapDevToolPlugin,
 } from "webpack";
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import webpackNodeExternals from "webpack-node-externals";
@@ -60,7 +59,7 @@ export function getSetup(options: Options) {
     });
 
     function getDevTool() {
-        return options.sourceMap ? "eval-source-map" : false;
+        return options.sourceMap;
     }
 
     function getEntry() {
@@ -112,16 +111,12 @@ export function getSetup(options: Options) {
                             cache: true,
                             extractComments: "all",
                             parallel: true,
-                            sourceMap: options.sourceMap,
+                            sourceMap: !!options.sourceMap,
                             terserOptions: {
                                 safari10: true,
                             },
                         }),
                         new OptimizeCSSAssetsPlugin(),
-                        new SourceMapDevToolPlugin({
-                            filename: 'sourcemaps/[file].map',
-                            exclude: ['vendor.js'],
-                        })
                     ],
                     [],
                 ),

--- a/packages/pixeloven-webpack/config/src/types.ts
+++ b/packages/pixeloven-webpack/config/src/types.ts
@@ -18,7 +18,7 @@ export interface Options {
     outputPath: string;
     profiling: boolean;
     publicPath: string;
-    sourceMap: string;
+    sourceMap: boolean | string;
     stats: Stats;
     target: Target;
 }

--- a/packages/pixeloven-webpack/config/src/types.ts
+++ b/packages/pixeloven-webpack/config/src/types.ts
@@ -18,7 +18,7 @@ export interface Options {
     outputPath: string;
     profiling: boolean;
     publicPath: string;
-    sourceMap: boolean;
+    sourceMap: string;
     stats: Stats;
     target: Target;
 }


### PR DESCRIPTION
https://github.com/pixeloven/pixeloven/issues/272

**Changelog:**

- SourceMap type string in config file `packages/pixeloven-webpack/config/src/helpers/shared.ts`
- `sourceMap: "eval-source-map"` set as default in compiler file `packages/pixeloven-webpack/compiler/src/index.ts`
- example package.json updated to use `--sourceMap=source-map`

**Tests Done**

- Tested by running `yarn build: development` in `apps/examples/ssr`
- If flags are not used (i.e `sourceMap`,  `sourceMap=source-map`) no maps are generated. 
- To test in `apps/examples/ssr` I updated package.json `yarn build: production` with `--sourceMap=source-map` and then ran, maps were built.

**Note**

`pixeloven-webpack/config/src/helpers/shared.ts` line 110 uses `TerserPlugin`

https://webpack.js.org/plugins/terser-webpack-plugin/#sourcemap
```
Works only with source-map, inline-source-map, hidden-source-map and nosources-source-map values for the devtool option.
```


