### PR TITLE
fix: copy all image types to dist

### DIFF
--- a/packages/pixeloven/cli-core/src/commands/copy.test.ts
+++ b/packages/pixeloven/cli-core/src/commands/copy.test.ts
@@ -43,7 +43,7 @@ describe("@pixeloven/cli", () => {
                 expect(Stub.process.exit.called).toEqual(true);
                 expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
             });
-            it("should copy ico", async () => {
+            it("should copy image", async () => {
                 const context = await cli.run("copy images");
                 expect(Stub.filesystem.copy.callCount).toEqual(1);
                 expect(Stub.print.success.callCount).toEqual(1);

--- a/packages/pixeloven/cli-core/src/commands/copy.test.ts
+++ b/packages/pixeloven/cli-core/src/commands/copy.test.ts
@@ -43,6 +43,14 @@ describe("@pixeloven/cli", () => {
                 expect(Stub.process.exit.called).toEqual(true);
                 expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
             });
+            it("should copy ico", async () => {
+                const context = await cli.run("copy images");
+                expect(Stub.filesystem.copy.callCount).toEqual(1);
+                expect(Stub.print.success.callCount).toEqual(1);
+                expect(context.commandName).toEqual("copy");
+                expect(Stub.process.exit.called).toEqual(true);
+                expect(Stub.process.exit.calledWithExactly(0)).toEqual(true);
+            });
             it("should copy scss", async () => {
                 const context = await cli.run("copy scss");
                 expect(Stub.filesystem.copy.callCount).toEqual(1);

--- a/packages/pixeloven/cli-core/src/commands/copy.ts
+++ b/packages/pixeloven/cli-core/src/commands/copy.ts
@@ -14,6 +14,13 @@ export default {
                 });
                 print.success(`Successfully copied ico files to dist`);
                 break;
+            case "images":
+                filesystem.copy("src", "dist/lib", {
+                    matching: "**/*.{jpg,jpeg,png,svg}",
+                    overwrite: true,
+                });
+                print.success(`Successfully copied image files to dist`);
+                break;
             case "scss":
                 filesystem.copy("src", "dist/lib", {
                     matching: "**/*.scss",
@@ -30,7 +37,7 @@ export default {
                 break;
             case "assets":
                 filesystem.copy("src", "dist/lib", {
-                    matching: "**/*.{ico,scss,svg}",
+                    matching: "**/*.{ico,jpg,jpeg,png,scss,svg}",
                     overwrite: true,
                 });
                 print.success(`Successfully copied assets to dist`);


### PR DESCRIPTION
We don't currently copy jpg or png file types but we need to support them for modern favicon components.