### PR TITLE
feat(DIE-320): strip inline scss comments from output

### DIFF
--- a/packages/pixeloven-webpack/config/package.json
+++ b/packages/pixeloven-webpack/config/package.json
@@ -34,6 +34,7 @@
         "optimize-css-assets-webpack-plugin": "5.0.3",
         "postcss-flexbugs-fixes": "4.1.0",
         "postcss-loader": "3.0.0",
+        "postcss-strip-inline-comments": "0.1.5",
         "react-dev-utils": "10.0.0",
         "sass": "1.26.2",
         "sass-loader": "8.0.2",

--- a/packages/pixeloven-webpack/config/src/helpers/shared.ts
+++ b/packages/pixeloven-webpack/config/src/helpers/shared.ts
@@ -9,6 +9,7 @@ import autoprefixer from "autoprefixer";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import OptimizeCSSAssetsPlugin from "optimize-css-assets-webpack-plugin";
 import path from "path";
+import stripInlineComments from "postcss-strip-inline-comments";
 import ModuleScopePlugin from "react-dev-utils/ModuleScopePlugin";
 import TerserPlugin from "terser-webpack-plugin";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
@@ -233,7 +234,6 @@ export function getSetup(options: Options) {
                             hmr: ifDevelopment(),
                         },
                     },
-
                     {
                         loader: require.resolve("css-loader"),
                     },
@@ -241,7 +241,7 @@ export function getSetup(options: Options) {
                         loader: require.resolve("postcss-loader"),
                         options: {
                             ident: "postcss",
-                            plugins: postCssPlugin,
+                            plugins: [postCssPlugin, stripInlineComments],
                         },
                     },
                     {

--- a/packages/pixeloven-webpack/config/src/modules.d.ts
+++ b/packages/pixeloven-webpack/config/src/modules.d.ts
@@ -3,6 +3,7 @@
  * @description Consult DefinitelyTyped before declaring below
  * http://definitelytyped.org/
  */
+declare module "postcss-strip-inline-comments";
 declare module "react-dev-utils/ModuleScopePlugin";
 declare module "react-dev-utils/FileSizeReporter";
 declare module "time-fix-plugin";

--- a/yarn.lock
+++ b/yarn.lock
@@ -10099,6 +10099,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -11973,6 +11978,11 @@ jest@26.0.1:
     "@jest/core" "^26.0.1"
     import-local "^3.0.2"
     jest-cli "^26.0.1"
+
+js-base64@^2.1.9:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
+  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -15287,6 +15297,13 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
+postcss-strip-inline-comments@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/postcss-strip-inline-comments/-/postcss-strip-inline-comments-0.1.5.tgz#7ff6bcdc14e633ed4cdfa020bae3eddad4f84b90"
+  integrity sha1-f/a83BTmM+1M36AguuPt2tT4S5A=
+  dependencies:
+    postcss "^5.0.18"
+
 postcss-svgo@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
@@ -15338,6 +15355,16 @@ postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17,
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^5.0.18:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -18182,6 +18209,13 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
In SCSS inline comments are perfectly valid, but when the SCSS is compiled to CSS webpack currently doesn't strip the comments out, so the linter complains and stops the compilation. Updated PostCSS to use a plugin to strip the comments from the output.