### PR TITLE
docs: update the docs for the recent changes to the component generator

### DIFF
--- a/apps/pixeloven/site/docs/api/cli-addon-generators.mdx
+++ b/apps/pixeloven/site/docs/api/cli-addon-generators.mdx
@@ -70,15 +70,16 @@ The generators are somewhat opinionated and make a few assumptions about the org
 #### Components
 
 1. To create a new component, run the `generate` command from the root of the host app or package and choose `Component` from the selection menu.
-1. Choose the appropriate atomic type for your component. Refer to the component docs to learn more about atomic design and how it's implemented in Pixeloven.
+1. Choose the appropriate Atomic type for your component. Refer to the [component docs to learn more](/recommendations/design-patterns#atomic-design-structure) about Atomic design and how it's implemented in Pixeloven.
 1. Choose the format of the component, we recommend Functional components if you're using React 16.4.x or later.
-1. Choose to manage state within your component. If you're unsure, choose `N`. It's easy enough to add this later if necessary.
+1. Choose to manage local state within your component. If you're unsure, choose `N`. It's easy enough to add this later if necessary.
 1. Choose to include styles with your component. If you're unsure, choose `N`. It's easy enough to add this later if necessary.
 1. Enter a component name following the naming conventions in the contributing docs.
 1. Enter a short description of what your component does. You can expand on the description in the component README.
-1. Enter a namespace for the component if necessary. These are slightly different from app and package namespaces as they're not use for publishing. These namespaces are used to group the components within each app and package within your project. For example of the components within our packages use a `packages/package-name` namespace format.
+1. Enter the directory path for your components. For apps this will typically be `src/shared/components` and for packages simply `src`.
+1. Enter a namespace for your components. These namespaces are used to group the components within each app and package within your project. For example of the components within our packages use a `packages/package-name` namespace format.
 
-Congrats, your brand new component is ready and waiting for you in `/src/components` under the directory that matches the atomic type you chose above, `cd` into it to get started and view the component docs to learn more.
+Congrats! Your brand new component is ready and waiting for you in the directory that matches the Atomic type you chose above. `cd` into it to get started and [view the component docs to learn more](/recommendations/react-components).
 
 #### Packages
 

--- a/apps/pixeloven/site/docs/api/cli-addon-generators.mdx
+++ b/apps/pixeloven/site/docs/api/cli-addon-generators.mdx
@@ -43,7 +43,7 @@ As mentioned above these types are optional and simply shortcut the first part o
 | `component` | Starts the interactive menu for generating a React component. |
 | `package`   | Starts the interactive menu for creating a new Package.       |
 
-### Usage
+## Usage
 
 Providing a type to generate is entirely optional. This argument is provided to help shortcuts the menu for a slightly more customized experience.
 
@@ -63,14 +63,14 @@ Finally, here is an example of how you might use these shortcuts to start the co
 yarn run pixeloven generate component
 ```
 
-### Details
+## Details
 
 The generators are somewhat opinionated and make a few assumptions about the organization of your project. See the instructions for each individual generator below for specifics.
 
-#### Components
+### Components
 
 1. To create a new component, run the `generate` command from the root of the host app or package and choose `Component` from the selection menu.
-1. Choose the appropriate Atomic type for your component. Refer to the [component docs to learn more](/recommendations/design-patterns#atomic-design-structure) about Atomic design and how it's implemented in Pixeloven.
+1. Choose the appropriate Atomic type for your component. Refer to the [Design Patterns documentation to learn more](/docs/recommendations/design-patterns#atomic-design-structure) about Atomic Design and how it's implemented in Pixeloven.
 1. Choose the format of the component, we recommend Functional components if you're using React 16.4.x or later.
 1. Choose to manage local state within your component. If you're unsure, choose `N`. It's easy enough to add this later if necessary.
 1. Choose to include styles with your component. If you're unsure, choose `N`. It's easy enough to add this later if necessary.
@@ -79,9 +79,9 @@ The generators are somewhat opinionated and make a few assumptions about the org
 1. Enter the directory path for your components. For apps this will typically be `src/shared/components` and for packages simply `src`.
 1. Enter a namespace for your components. These namespaces are used to group the components within each app and package within your project. For example of the components within our packages use a `packages/package-name` namespace format.
 
-Congrats! Your brand new component is ready and waiting for you in the directory that matches the Atomic type you chose above. `cd` into it to get started and [view the component docs to learn more](/recommendations/react-components).
+Congrats! Your brand new component is ready and waiting for you in the directory that matches the Atomic type you chose above. `cd` into it to get started and refer to the [React Component docs to learn more](/docs/recommendations/react-components).
 
-#### Packages
+### Packages
 
 1. To start a new package, run the `generate` command from the root of your project and choose `Package` from the selection menu.
 1. Enter a package name following the naming conventions in the contributing docs.
@@ -95,7 +95,7 @@ Congrats! Your brand new component is ready and waiting for you in the directory
 
 Congrats, your brand new package is ready and waiting for you in the `/packages` directory, `cd` into it to get started and view the packages docs to learn more.
 
-#### Applications
+### Applications
 
 1. To start a new app, run the `generate` command from the root of your project and choose `App` from the selection menu.
 1. Enter an app name following the naming conventions in the contributing docs.

--- a/apps/pixeloven/site/docs/recommendations/design-patterns.mdx
+++ b/apps/pixeloven/site/docs/recommendations/design-patterns.mdx
@@ -60,7 +60,7 @@ To make referencing source files easier we have set up three aliases that are av
 
 Further down into our `src/shared/components` directory structure we have adopted Atomic Design philosophies for creating and managing React components. Please reference [react-atomic-design](https://github.com/danilowoz/react-atomic-design) for details on what Atomic Design is and how it is applied to React.
 
-> Note it is worth mentioning that we use our own customized setup but generally all the same patterns still apply.
+> Note: It is worth mentioning that we use our own customized setup but generally all the same patterns still apply.
 
 For reference when we refer to `un-connected` or `connected` we are referring to a components to the relationship application state (redux).
 
@@ -88,7 +88,7 @@ Though these elements are generally connected to an application state, it is not
 
 When creating any new components make sure to follow the pattern below. In this example we will walk through creating a small `atom` component but these same patterns should apply regardless of scope.
 
-_Note: To make component creation easier, we provide a generator that will automatically create and initialize all the necessary component files. Refer to the [CLI Addon Generators documentation to learn more](/docs/api/cli-addon-generators#components)._
+> Note: To make component creation easier, we provide a generator that will automatically create and initialize all the necessary component files. Refer to the [CLI Addon Generators documentation to learn more](/docs/api/cli-addon-generators#components).
 
 First we must create a directory structure for our Atomic components.
 
@@ -100,7 +100,7 @@ src/shared/components/
 
 Once our Atomic directory is complete we can create our component directory. Here we will define all our support files for our component, ensuring that the name of the component comes first followed by the appropriate file type (scss, stories, test, etc).
 
-_Note: Co-locating the component's support files and sharing the component name makes local development far easier versus spreading files throughout the application or naming every component file `index.tsx`. The `index.ts` file is still necessary, but only to export the component at the component directory level and shouldn't contain any other component code._
+> Note: Co-locating the component's support files and sharing the component name makes local development far easier versus spreading files throughout the application or naming every component file `index.tsx`. The `index.ts` file is still necessary, but only to export the component at the component directory level and shouldn't contain any other component code.
 
 ```
 atoms

--- a/apps/pixeloven/site/docs/recommendations/design-patterns.mdx
+++ b/apps/pixeloven/site/docs/recommendations/design-patterns.mdx
@@ -66,7 +66,7 @@ For reference when we refer to `un-connected` or `connected` we are referring to
 
 ### Un-connected components
 
-These comments are blind to application state but all may contain logic or internal state mechanisms. As a general rule the further up the Atomic structure you go the more complex both logic and state may become.
+These components are blind to application state but all may contain logic or internal state mechanisms. As a general rule the further up the Atomic structure you go the more complex both logic and state may become.
 
 | Directory   | Description                                                                                                                                                                                                                            |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/pixeloven/site/docs/recommendations/design-patterns.mdx
+++ b/apps/pixeloven/site/docs/recommendations/design-patterns.mdx
@@ -3,7 +3,7 @@ id: design-patterns
 title: Design Patterns
 ---
 
-## Application files structure
+## Application file structure
 
 This section is both documentation for our own application structure and recommended structure for derivative apps.
 
@@ -40,9 +40,9 @@ Starting with each application you will find the following structure.
 | `src`          | Alright the fun part! Contains all the source files used to build our application.                                                   |
 | `stats`        | Webpack bundle analysis stats                                                                                                        |
 
-### Source files and aliases
+## Source file structure and aliases
 
-Our source files require a bit more in depth discussion. Our source files are meant to be built in an isomorphic style. Isomorphic or Universal JavaScript is meant to reduce the amount of repeated code and context switching but often comes at the cost of complexity. We introduced a simple file structure to help us reduce thrashing when working in this context.
+Our source files require a bit more in depth discussion due to being organized in an isomorphic style. Isomorphic or Universal JavaScript is meant to reduce the amount of repeated code and context switching but often comes at the cost of complexity. We introduced a standard file structure to help us reduce thrashing when working in this context.
 
 | Directory    | Description                                                                   |
 | ------------ | ----------------------------------------------------------------------------- |
@@ -50,51 +50,68 @@ Our source files require a bit more in depth discussion. Our source files are me
 | `src/server` | This is the entry point for our build process for all server side code paths. |
 | `src/shared` | Contains all source that is universal to the two code paths.                  |
 
-### Atomic design structure
+To make referencing source files easier we have set up three aliases that are available from within an app.
 
-Further down into our `src/shared/components` directory structure we have adopted Atomic Design philosophies for creating and managing react components. Please reference [react-atomic-design](https://github.com/danilowoz/react-atomic-design) for details on what Atomic Design is and how it is applied to react.
+-   `@client` which points to `src/client/*`
+-   `@server` which points to `src/server/*`
+-   `@shared` which points to `src/shared/*`
+
+## Atomic design structure
+
+Further down into our `src/shared/components` directory structure we have adopted Atomic Design philosophies for creating and managing React components. Please reference [react-atomic-design](https://github.com/danilowoz/react-atomic-design) for details on what Atomic Design is and how it is applied to React.
 
 > Note it is worth mentioning that we use our own customized setup but generally all the same patterns still apply.
 
 For reference when we refer to `un-connected` or `connected` we are referring to a components to the relationship application state (redux).
 
-#### Un-connected elements
+### Un-connected components
 
-These comments are blind to application state but all may contain logic or internal state mechanisms. As a general rule the further up the atomic structure you go the more complex both logic and state may become.
+These comments are blind to application state but all may contain logic or internal state mechanisms. As a general rule the further up the Atomic structure you go the more complex both logic and state may become.
 
--   `atoms` The smallest based elements used as building blocks for everything else. These often are very self contained units are almost purely stateless.
--   `molecules` Often made up of a small collection of atoms. They generally follow a similar rule as atoms but at a slightly larger scale.
--   `organisms` Like molecules to atoms these elements are made up of a collection of both. They often will contain some internal logic or state.
+| Directory   | Description                                                                                                                                                                                                                            |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `atoms`     | The smallest based elements used as building blocks for everything else. These often are very self contained components and should almost always be stateless.                                                                         |
+| `molecules` | Often made up of a small collection of Atoms. They generally follow a similar rule as atoms but at a slightly larger scale. What little state they may contain should be entirely localized to controlling the components within them. |
+| `organisms` | Like Molecules to Atoms these elements are made up of a collection of both. They often will contain some internal logic or state to control the components within them.                                                                |
 
-#### Connected elements
+### Connected components
 
-Though these elements are generally connected to an application state it is not a requirement. Anyone of these may rely on purely component state or even be completely static.
+Though these elements are generally connected to an application state, it is not a requirement. Any of these may rely purely on local state, or even be completely static.
 
--   `pages` Pages are made up of a collection of our atomic elements they are almost always connected to state and are highly specific.
--   `partials` Partials are some what in between the two other components of this class. They are some what self contained sections that may are may not be reusable but are not application entry points. Usually a Page may consist of a few of these in the case of a modal or a popup.
--   `templates` Similar to pages these elements are made up of atomic elements and are also often connected to state. However, where they differ is in them not being very specific but instead striving for a generic stance.
+| Directory   | Description                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `partials`  | Partials are some what in-between the other two components types of connected components. They are some what self contained sections that may or may not be reusable but are not application entry points. A typical Page may consist of a few of these in the case of a modal or a popup.                                                                                         |
+| `pages`     | Pages are made up of a collection of our Atomic components, are almost always connected to state, and are highly specific to their use case within your application.                                                                                                                                                                                                               |
+| `templates` | Similar to Pages these elements are made up of a collection of Atomic components, including Pages, and are often connected to state. However, they differ from Pages by striving to be very generic. Think of these as the outermost wrappers that contain the components each of our Pages might share, like a Header and Footer component, with our Pages rendered between them. |
 
 ## Component structure
 
-When creating any new components we should follow the below pattern. In this example we will assume that we are creating a small `atomic` component. However, it should be noted that these same patterns should apply regardless of scope.
+When creating any new components make sure to follow the pattern below. In this example we will walk through creating a small `atom` component but these same patterns should apply regardless of scope.
 
-First we must decide where our component should live.
+_Note: To make component creation easier, we provide a generator that will automatically create and initialize all the necessary component files. Refer to the [CLI Addon Generators documentation to learn more](/docs/api/cli-addon-generators#components)._
+
+First we must create a directory structure for our Atomic components.
 
 ```
-...
-components
+src/shared/components/
 └── atoms
-```
-
-Once this decision has been made we will want to created our component directory. In this directory we should define all our independent pieces such that the name of the component comes first followed by what it is used for.
-
-```
 ...
-Logo
-├── Logo.scss
-├── Logo.stories.tsx
-├── Logo.test.tsx
-├── Logo.tsx
-├── index.ts
-└── README.md
 ```
+
+Once our Atomic directory is complete we can create our component directory. Here we will define all our support files for our component, ensuring that the name of the component comes first followed by the appropriate file type (scss, stories, test, etc).
+
+_Note: Co-locating the component's support files and sharing the component name makes local development far easier versus spreading files throughout the application or naming every component file `index.tsx`. The `index.ts` file is still necessary, but only to export the component at the component directory level and shouldn't contain any other component code._
+
+```
+atoms
+└── Logo
+    ├── Logo.scss
+    ├── Logo.stories.tsx
+    ├── Logo.test.tsx
+    ├── Logo.tsx
+    ├── index.ts
+    └── README.md
+...
+```
+
+Continue on to learn about working with React Components.

--- a/apps/pixeloven/site/docs/recommendations/react-components.mdx
+++ b/apps/pixeloven/site/docs/recommendations/react-components.mdx
@@ -21,7 +21,7 @@ _Note: Be extremely cautious when importing from a shared directory such as this
 import { Button, Link, Logo } from "@shared/components/atoms";
 ```
 
-We provide a few aliases for our source directories, refer to the [Design Patterns documentation to learn more](/docs/reccommendations/design-patterns#source-file-structure-and-aliases).
+We provide a few aliases for our source directories, refer to the [Design Patterns documentation to learn more](/docs/recommendations/design-patterns#source-file-structure-and-aliases).
 
 ## Supporting files
 

--- a/apps/pixeloven/site/docs/recommendations/react-components.mdx
+++ b/apps/pixeloven/site/docs/recommendations/react-components.mdx
@@ -75,4 +75,49 @@ ADD LINK TO DOCUMENTATION ON ROUTES
 
 ## Component composition
 
-ADD DOCUMENTATION ON COMPONENT COMPOSITION
+When it comes to extracting components, there are two important factors to consider:
+1. complexity of code (e.g. conditional rendering and other business logic)
+2. reusability of code
+
+We use the Atomic Design as our philosophy for creating reusable React components, along with additional co-located support files for each new component. However, sometimes an Atomic component itself might include complex business logic for rendering, or code that is reused only within that component, and extracting some of its pieces into their own components would help improve readability and maintainability of the code. If you see that these pieces need to be extracted into their own component, yet they do not warrant creating the additional supporting files, then simply create a co-located React component within the original component folder and import it into the original component. Any necessary styles, stories, or tests then live within the original support files.
+
+In the example below, `MetadataIndicator` is a Molecule component and it requires complex business for rendering several indicators. `FirstIndicator` and `SecondIndicator` in the end both render the same Molecule component, however they use widely different business logic and copy. Extracting these implementations into two separate components lets us clearly see the logic that the parent, `MetadataIndicator`, uses to decide which indicator to render. `FirstIndicator` and `SecondIndicator`, in turn, are responsible for logic specific to them. Since they are not being used anywhere else, they do not warrant creation of a new Atomic component with new support files, so they are kept within the same directory as their parent, `molecules/MetadataIndicator`.
+
+In this case, both complexity and reusability played a role in the decision to extract the components. Reusability is frequently a more obvious reason, however, complexity alone could warrant extraction, depending on the situation. The goal is to improve readability of the code for us humans, which will make it easier for us to reason about and modify the code as needed in the future.
+
+As [React docs](https://reactjs.org/docs/components-and-props.html#extracting-components) put it: "Don’t be afraid to split components into smaller components." :)
+
+```
+src/shared/components/molecules/MetadataIndicator
+├── FirstIndicator.tsx
+├── index.ts
+├── MetadataIndicator.scss
+├── MetadataIndicator.stories.tsx
+├── MetadataIndicator.test.tsx
+├── MetadataIndicator.tsx
+├── README.md
+└── SecondIndicator.tsx
+```
+
+```javascript
+function MetadataIndicator(props) {
+    if (showFirstIndicator && showSecondIndicator) {
+        return (
+            <React.Fragment>
+                <FirstIndicator />
+                <SecondIndicator />
+            </React.Fragment>
+        );
+    } else if (showFirstIndicator) {
+        return (
+            <FirstIndicator />
+        );
+    } else if (showSecondIndicator) {
+        return (
+            <SecondIndicator />
+        );
+    }
+
+    return <React.Fragment />;
+}
+```

--- a/apps/pixeloven/site/docs/recommendations/react-components.mdx
+++ b/apps/pixeloven/site/docs/recommendations/react-components.mdx
@@ -3,33 +3,31 @@ id: react-components
 title: React Components
 ---
 
-This document is general advice for creating and working with new components.
+This document is general advice for working with React components.
 
 ## Referencing source files
 
-To make referencing source files easier we have set up three simple aliases when working inside an app.
-
--   `@client` which points to `src/client/*`
--   `@server` which points to `src/server/*`
--   `@shared` which points to `src/shared/*`
-
-Example usage would be as follows:
+To make referencing source files easier we have set up a `@shared` directory alias to simplify import declarations vs having to navigate up and down the directory tree. For example, to import a Logo Atom into another component we'd write:
 
 ```javascript
 import { Logo } from "@shared/components/atoms/Logo";
 ```
 
-Alternatively we can also create an `index.ts` file in the atoms directory and export all of our **atoms** allowing us to reference multiple at once.
+Alternatively we can also create an `index.ts` file in the atoms directory and export all of our Atom components, allowing us to reference multiple at once.
+
+_Note: Be extremely cautious when importing from a shared directory such as this. If the component we're importing into is exported from the same directory as the component we're importing, it will create a circular dependency. This can create bugs that are difficult to track down, slow down our application, or even create heap memory issues that result in our application crashing._
 
 ```javascript
-import { Logo } from "@shared/components/atoms";
+import { Button, Link, Logo } from "@shared/components/atoms";
 ```
+
+We provide a few aliases for our source directories, refer to the [Design Patterns documentation to learn more](/docs/reccommendations/design-patterns#source-file-structure-and-aliases).
 
 ## Supporting files
 
-Our components may also contain other important files. For instance this framework supports the use of localized stylesheets with `Logo.scss`. It is also highly recommended that all _stories_ be accompanied by a `README.md` file to help with development.
+We rely on co-location for our component's supporting files, including styles, tests, stories, and documentation. We find co-locating the supporting files makes development far easier versus spreading them throughout the application. We highly recommend that all `stories.tsx` be accompanied by a `README.md` file to document and aid other developers working with the component.
 
-And finally we have our `index.ts`. This file should simply export our component for consumption in the general application.
+The `index.ts` file is necessary, but only to export the component at the component directory level and shouldn't contain any other component code. For example, to export the component we'd write:
 
 ```javascript
 /**
@@ -43,13 +41,13 @@ export { default as LogoConnected } from "./Logo.connect";
 
 ## Connecting a component to state
 
-If this component needs to _connect_ to [redux](https://redux.js.org/) state then it will need the following file(s).
+If this component needs to _connect_ to [Redux](https://redux.js.org/) state then it will also need a co-located connect file.
 
 ```
 Logo.connect.ts
 ```
 
-Here's a simple example of what this file might look like.
+Here's a simplified example of what this file might look like.
 
 ```javascript
 const makeMapStateToProps = () => {
@@ -71,4 +69,10 @@ const LogoConnect = connect(
 export default LogoConnect;
 ```
 
-The reason for this separation is primarily for testability but it also allows us to use a component in multiple contexts (with or without redux). The only reference to a connected component should be with in our route config.
+We separate the application state management primarily for testability, but it also allows us to use a component in multiple contexts (with or without Redux). The only reference to a connected component should be with in our route config.
+
+ADD LINK TO DOCUMENTATION ON ROUTES
+
+## Component composition
+
+ADD DOCUMENTATION ON COMPONENT COMPOSITION

--- a/apps/pixeloven/site/docs/recommendations/react-components.mdx
+++ b/apps/pixeloven/site/docs/recommendations/react-components.mdx
@@ -15,7 +15,7 @@ import { Logo } from "@shared/components/atoms/Logo";
 
 Alternatively we can also create an `index.ts` file in the atoms directory and export all of our Atom components, allowing us to reference multiple at once.
 
-_Note: Be extremely cautious when importing from a shared directory such as this. If the component we're importing into is exported from the same directory as the component we're importing, it will create a circular dependency. This can create bugs that are difficult to track down, slow down our application, or even create heap memory issues that result in our application crashing._
+> Note: Be extremely cautious when importing from a shared directory such as this. If the component we're importing into is exported from the same directory as the component we're importing, it will create a circular dependency. This can create bugs that are difficult to track down, slow down our application, or even create heap memory issues that result in our application crashing.
 
 ```javascript
 import { Button, Link, Logo } from "@shared/components/atoms";

--- a/apps/pixeloven/site/docs/recommendations/working-with-libraries.mdx
+++ b/apps/pixeloven/site/docs/recommendations/working-with-libraries.mdx
@@ -3,27 +3,29 @@ id: working-with-libraries
 title: Working with libraries
 ---
 
-This document is general advice for creating new components and utilities.
+When working with third party libraries we often find the library will lack type definitions (this is starting to improve as the community adopts TypeScript). In these situations we need to include community definitions, declare our own, or in extreme cases, ignore the lack of types.
 
 ## Community definitions
 
-Generally the TypeScript community has or will define definitions for lots of scenarios. If you are using a package or library try to first look at [DefinitelyTyped](https://definitelytyped.org/).
+Generally the TypeScript community has or will create definitions for most scenarios. If you are using a library that doesn't include it's own types, try to search for the library in [DefinitelyTyped](https://definitelytyped.org/). If that fails you can also search NPM repository for `@types/*` where `*` is the package name. As a last resort, search Google before moving to the options below.
 
-If that fails you can also search NPM repository for `@types/*` where `*` is the package name. As a last resort before moving to the below options is to search google. :)
+## Un-typed libraries
 
-## Declaration files
+For un-typed libraries we recommend attempting to declare custom type definitions, but in some cases when that is too tedious or even impossible we have an option to move forward using module files.
 
-Declaring definitions can be necessary for when a module is un-typed or when using an external API.
+### Declaration files
 
-> Note this is the right way to import an un-typed module or file. However, it is a tedious process and so it is recommended to first search for types from the community (shown above) or if too cumbersome do what is show below in the next sub sections.
+Declaring custom definitions for a library may be necessary when a module is un-typed or when using an external API.
 
-### Custom definitions
+> Note: This is the right way to import an un-typed module or file. However, it is a tedious process and so it is recommended to first search for types from the community (shown above) or if too cumbersome use module files (shown below).
 
-It is possible to write types for a third party package. In these cases it is recommended to follow TypeScripts own documentation on [declaration files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html).
+#### Custom definitions
 
-### External APIs
+When defining types for a third party library we recommend following TypeScript's own [documentation for declaration files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html).
 
-In this example we are working with a specific API defined by an IE browser. We created a file `dom.ie.d.ts` and placed the below contents.
+#### External APIs
+
+Typescript's built in type definitions do not include vendor-specific DOM specs. When working with custom external APIs we will often need to define our oun interfaces, for example when working with a specific API defined by an IE browser. Here we create a `dom.ie.d.ts` file and define the `msMatchesSelector` method within the `Element` interface.
 
 ```javascript
 interface Element {
@@ -31,35 +33,33 @@ interface Element {
 }
 ```
 
-For this example we can see why this is needed from this [stack overflow page](https://stackoverflow.com/questions/53040790/ts2339-property-msmatchesselector-does-not-exist-on-type-element?noredirect=1&lq=1).
+For issues like this example, Google is your best friend. We found [this issue with a solution on Stack Overflow](https://stackoverflow.com/questions/53040790/ts2339-property-msmatchesselector-does-not-exist-on-type-element?noredirect=1&lq=1).
 
-## Un-typed libraries
+### Module files
 
-For un-typed modules and libraries it is recommended that you attempt to come up with your own type definitions but if it is found to be too tedious or even impossible we have an option to move forward. Generally this is meant to help define custom types for an un-typed module. However, for quicker integration we often use this as a way to blanket accept a module without types.
+Generally this is meant to help define custom types for an un-typed module. However, for quicker integration we sometimes use this as a way to blanket accept a module without types.
 
-> Note this practice should be discourage for most cases so please **Use sparingly**.
+> Note: This practice should be discourage for most cases so please **Use sparingly**
 
-In your application locate or create a file `./src/modules.d.ts`. In this file you will want to declare a module like below.
+We start by locating or creating a `./src/modules.d.ts` file and declaring the module. For example:
 
 ```javascript
-declare module "import-module-name";
+declare module "external-module-name";
 ```
 
-Where `import-module-name` is the name used for importing the module into your source.
+Where `external-module-name` is the library name used for importing the module into your source.
 
 ```javascript
-import woot from "import-module-name";
+import woot from "external-module-name";
 ```
 
 ## Turning off type-checking
 
-Occasionally, you may need to disable type checking if you're using a feature
-that is not supported by the current `@type/*` library. If that is case you can
-use one of the following to disable type-checking:
+Occasionally, we may encounter situations where we need to disable type checking, for example when using a feature that is not supported by the current `@type/*` library. In these cases we will use one of the following to disable type-checking:
 
-> Note this practice should be discourage for most cases so please **Use sparingly**.
+> Note: This practice should be discourage for most cases so please **Use sparingly**.
 
 -   `// @ts-ignore`: disables checking for the next line
 -   `// @ts-nocheck`: disables checking for the whole file
 
-For information see TypeScripts documentation on [type checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html)
+For more information refer to [TypeScript's documentation on type checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html)

--- a/apps/pixeloven/site/sidebars.json
+++ b/apps/pixeloven/site/sidebars.json
@@ -36,8 +36,8 @@
         "Recommendations": [
             "recommendations/intro",
             "recommendations/design-patterns",
-            "recommendations/working-with-libraries",
-            "recommendations/react-components"
+            "recommendations/react-components",
+            "recommendations/working-with-libraries"
         ]
     }
 }


### PR DESCRIPTION
I ended up editing the design patterns and react component docs to reduce duplication and flow better as a set of connected instructions on top of updating the component generator docs. I still need to finish with links to route docs and talk to Ksenia about adding some of her notes on component composition.

To test: checkout `update-generator-docs` and cd to `apps/pixeloven/site`. Run `yarn && yarn start` to get the docsite running locally.